### PR TITLE
Export `.mss` code complete`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,8 +108,10 @@ add_executable(denigma
 # Compile definitions
 target_compile_definitions(denigma PRIVATE MUSX_USE_TINYXML2)
 target_compile_definitions(denigma PRIVATE MUSX_USE_RAPIDXML)
- # temporary for reference
+
+# temporary for reference and debugging
 target_compile_definitions(denigma PRIVATE MUSX_DISPLAY_NODE_NAMES)
+target_compile_definitions(denigma PRIVATE MUSX_THROW_ON_UNKNOWN_XML)
 
 # Ensure the include directories are added
 add_dependencies(denigma GenerateMnxSchemaXxd)

--- a/src/enigmaxml/enigmaxml.cpp
+++ b/src/enigmaxml/enigmaxml.cpp
@@ -24,10 +24,10 @@
 #include <vector>
 #include <iostream>
 
+#include "musx/musx.h"
 #include "enigmaxml.h"
 #include "zip_file.hpp"		// miniz submodule (for zip)
 #include "ezgz.hpp"			// ezgz submodule (for gzip)
-#include "musx/musx.h"
 
 constexpr char SCORE_DAT_NAME[] = "score.dat";
 

--- a/src/mss/mss.cpp
+++ b/src/mss/mss.cpp
@@ -64,6 +64,8 @@ struct FinalePrefences
 {
     DocumentPtr document;
     std::shared_ptr<FontInfo> defaultMusicFont;
+    //
+    std::shared_ptr<options::AlternateNotationOptions> alternateNotationOptions;
     std::shared_ptr<options::BarlineOptions> barlineOptions;
     std::shared_ptr<options::ClefOptions> clefOptions;
     std::shared_ptr<options::KeySignatureOptions> keyOptions;
@@ -92,6 +94,8 @@ static FinalePrefencesPtr getCurrentPrefs(const enigmaxml::Buffer& xmlBuffer, bo
 
     auto fontOptions = getDocOptions<options::FontOptions>(retval, "font");
     retval->defaultMusicFont = fontOptions->getFontInfo(options::FontOptions::FontType::Music);
+    //
+    retval->alternateNotationOptions = getDocOptions<options::AlternateNotationOptions>(retval, "alternate notation");
     retval->barlineOptions = getDocOptions<options::BarlineOptions>(retval, "barline");
     retval->clefOptions = getDocOptions<options::ClefOptions>(retval, "clef");
     retval->keyOptions = getDocOptions<options::KeySignatureOptions>(retval, "key signature");
@@ -332,7 +336,7 @@ void writeLineMeasurePrefs(XmlElement* styleElement, const FinalePrefencesPtr& p
     setElementValue(styleElement, "clefBarlineDistance", prefs->repeatOptions->afterClefSpace / EVPU_PER_SPACE);
     setElementValue(styleElement, "timesigBarlineDistance", prefs->repeatOptions->afterClefSpace / EVPU_PER_SPACE);
 
-    setElementValue(styleElement, "measureRepeatNumberPos", -(double(prefs->repeatOptions->bracketTextVPos) + 0.5) / EVPU_PER_SPACE);
+    setElementValue(styleElement, "measureRepeatNumberPos", -(prefs->alternateNotationOptions->twoMeasNumLift + 0.5) / EVPU_PER_SPACE);
     setElementValue(styleElement, "staffLineWidth", prefs->lineCurveOptions->staffLineWidth / EFIX_PER_SPACE);
     setElementValue(styleElement, "ledgerLineWidth", prefs->lineCurveOptions->legerLineWidth / EFIX_PER_SPACE);
     setElementValue(styleElement, "ledgerLineLength", 
@@ -340,7 +344,7 @@ void writeLineMeasurePrefs(XmlElement* styleElement, const FinalePrefencesPtr& p
     setElementValue(styleElement, "keysigAccidentalDistance", (prefs->keyOptions->acciAdd + 4) / EVPU_PER_SPACE); // Observed fudge factor
     setElementValue(styleElement, "keysigNaturalDistance", (prefs->keyOptions->acciAdd + 6) / EVPU_PER_SPACE); // Observed fudge factor
 
-    setElementValue(styleElement, "smallClefMag", double(prefs->clefOptions->clefChangePercent) / 100.0);
+    setElementValue(styleElement, "smallClefMag", prefs->clefOptions->clefChangePercent / 100.0);
     setElementValue(styleElement, "genClef", !prefs->clefOptions->showClefFirstSystemOnly);
     setElementValue(styleElement, "genKeysig", !prefs->keyOptions->showKeyFirstSystemOnly);
     setElementValue(styleElement, "genCourtesyTimesig", prefs->timeOptions->cautionaryTimeChanges);

--- a/src/mss/mss.cpp
+++ b/src/mss/mss.cpp
@@ -46,7 +46,7 @@ constexpr static double EFIX_PER_EVPU = 64.0;
 constexpr static double EFIX_PER_SPACE = EVPU_PER_SPACE * EFIX_PER_EVPU;
 constexpr static double MUSE_FINALE_SCALE_DIFFERENTIAL = 20.0 / 24.0;
 
-static const std::set<std::string_view> museScoreSMuFlFonts{
+static const std::set<std::string_view> museScoreSMuFLFonts{
     "Bravura",
     "Leland",
     "Emmentaler",
@@ -235,8 +235,14 @@ static void writePagePrefs(XmlElement* styleElement, const FinalePrefencesPtr& p
 
     // Default music font
     auto defaultMusicFont = prefs->defaultMusicFont;
-    auto it = museScoreSMuFlFonts.find(defaultMusicFont->getFontName());
-    if (it != museScoreSMuFlFonts.end()) {
+    bool isSMuFL = [defaultMusicFont]() -> bool {
+        if (defaultMusicFont->calcIsSMuFL()) {
+            return true;
+        }
+        auto it = museScoreSMuFLFonts.find(defaultMusicFont->getFontName());
+        return it != museScoreSMuFLFonts.end();
+    }();
+    if (isSMuFL) {
         setElementValue(styleElement, "musicalSymbolFont", defaultMusicFont->getFontName());
         setElementValue(styleElement, "musicalTextFont", defaultMusicFont->getFontName() + " Text");
     }

--- a/src/mss/mss.cpp
+++ b/src/mss/mss.cpp
@@ -414,10 +414,7 @@ void writeNoteRelatedPrefs(XmlElement* styleElement, const FinalePreferencesPtr&
 #if 0
     setElementValue(styleElement, "concertPitch", prefs->partScopeOptions->displayInConcertPitch);
 #endif
-
-    // `math.abs(layer_one_prefs.RestOffset) >= 4` equivalent could not be fully resolved
     setElementValue(styleElement, "multiVoiceRestTwoSpaceOffset", std::labs(prefs->layerOneAttributes->restOffset) >= 4);
-
     setElementValue(styleElement, "mergeMatchingRests", prefs->miscOptions->consolidateRestsAcrossLayers);
 }
 

--- a/src/mss/mss.cpp
+++ b/src/mss/mss.cpp
@@ -85,8 +85,8 @@ static FinalePrefencesPtr getCurrentPrefs(const enigmaxml::Buffer& xmlBuffer)
     auto retval = std::make_shared<FinalePrefences>();
     retval->document = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(xmlBuffer);
 
-    auto defaultFonts = getDocOptions<options::DefaultFonts>(retval, "font");
-    retval->defaultMusicFont = defaultFonts->getFontInfo(options::DefaultFonts::FontType::Music);
+    auto fontOptions = getDocOptions<options::FontOptions>(retval, "font");
+    retval->defaultMusicFont = fontOptions->getFontInfo(options::FontOptions::FontType::Music);
     retval->barlineOptions = getDocOptions<options::BarlineOptions>(retval, "barline");
     retval->clefOptions = getDocOptions<options::ClefOptions>(retval, "clef");
     retval->lineCurveOptions = getDocOptions<options::LineCurveOptions>(retval, "lines & curves");
@@ -138,9 +138,9 @@ static uint16_t museFontEfx(const FontInfo* fontInfo)
     return retval;
 }
 
-static double museMagVal(const FinalePrefencesPtr& prefs, const options::DefaultFonts::FontType type)
+static double museMagVal(const FinalePrefencesPtr& prefs, const options::FontOptions::FontType type)
 {
-    auto fontPrefs = options::DefaultFonts::getFontInfo(prefs->document, type);
+    auto fontPrefs = options::FontOptions::getFontInfo(prefs->document, type);
     if (fontPrefs->getFontName() == prefs->defaultMusicFont->getFontName()) {
         return double(fontPrefs->fontSize) / double(prefs->defaultMusicFont->fontSize);
     }
@@ -156,9 +156,9 @@ static void writeFontPref(XmlElement* styleElement, const std::string& namePrefi
     setElementValue(styleElement, namePrefix + "FontStyle", museFontEfx(fontInfo));
 }
 
-static void writeDefaultFontPref(XmlElement* styleElement, const FinalePrefencesPtr& prefs, const std::string& namePrefix, options::DefaultFonts::FontType type)
+static void writeDefaultFontPref(XmlElement* styleElement, const FinalePrefencesPtr& prefs, const std::string& namePrefix, options::FontOptions::FontType type)
 {
-    auto fontPrefs = options::DefaultFonts::getFontInfo(prefs->document, type);
+    auto fontPrefs = options::FontOptions::getFontInfo(prefs->document, type);
     writeFontPref(styleElement, namePrefix, fontPrefs.get());
 }
 
@@ -261,7 +261,7 @@ static void writePagePrefs(XmlElement* styleElement, const FinalePrefencesPtr& p
 
 static void writeLyricsPrefs(XmlElement* styleElement, const FinalePrefencesPtr& prefs)
 {
-    auto fontInfo = options::DefaultFonts::getFontInfo(prefs->document, options::DefaultFonts::FontType::LyricVerse);
+    auto fontInfo = options::FontOptions::getFontInfo(prefs->document, options::FontOptions::FontType::LyricVerse);
     for (auto [verseNumber, evenOdd] : {
             std::make_pair(1, "Odd"),
             std::make_pair(2, "Even")


### PR DESCRIPTION
This version can now export a `.mss` file that is identical to that produced by the Lua script. But the advantage of `denigma` is that Finale is not required.
