### PR TITLE
Fix segfault when Finale file is not found (massage command)

### DIFF
--- a/src/massage/musicxml.cpp
+++ b/src/massage/musicxml.cpp
@@ -77,10 +77,12 @@ void MassageMusicXmlContext::logMessage(LogMsg&& msg, LogSeverity severity)
         std::string staffText = "p" + std::to_string(currentMusicXmlPart);
         auto staffNumber = Cmper(currentStaff + currentStaffOffset);
         std::string staffName = [&]() -> std::string {
-            auto iuList = musxDocument->getOthers()->getArrayForPart<others::InstrumentUsed>(musxPartId, 0); // 0 is the master list of staves in Scroll View
-            if (!iuList.empty()) { 
-                if (auto staff = others::InstrumentUsed::getStaffAtIndex(iuList, staffNumber)) {
-                    return staff->getFullName();
+            if (musxDocument) {
+                auto iuList = musxDocument->getOthers()->getArrayForPart<others::InstrumentUsed>(musxPartId, 0); // 0 is the master list of staves in Scroll View
+                if (!iuList.empty()) {
+                    if (auto staff = others::InstrumentUsed::getStaffAtIndex(iuList, staffNumber)) {
+                        return staff->getFullName();
+                    }
                 }
             }
             return "Staff " + std::to_string(staffNumber);

--- a/tests/denigmatests.cpp
+++ b/tests/denigmatests.cpp
@@ -60,7 +60,7 @@ void checkStderr(const std::vector<std::string>& expectedMessages, std::function
             EXPECT_TRUE(capturedErrors.empty()) << "No error message expected but got " << capturedErrors;
         } else {
             EXPECT_NE(capturedErrors.find(expectedMessage), std::string::npos)
-                << "Expected error message not found. Actual: " << capturedErrors;
+                << "Error message \"" << expectedMessage << "\" not found. Actual: " << capturedErrors;
         }
     }
 };

--- a/tests/test_massage.cpp
+++ b/tests/test_massage.cpp
@@ -258,3 +258,15 @@ TEST(Massage, Parts)
         compareFiles(referencePathPart, getOutputPath() / "-exports" / musicXmlFilenamePart);
     }
 }
+
+TEST(Massage, NoFinaleFile)
+{
+    setupTestDataPaths();
+    std::string inputFile = "notAscii-其れ";
+    std::filesystem::path inputPath;
+    copyInputToOutput("musicxml/" + inputFile + ".musicxml", inputPath); // inputPath now points to musicxml file
+    ArgList args = { DENIGMA_NAME, "massage", inputPath.u8string(), "--finale-file", "." };
+    checkStderr({ "Corresponding Finale document not found", inputFile + ".musicxml" }, [&]() {
+        EXPECT_EQ(denigmaTestMain(args.argc(), args.argv()), 0) << "create from " << inputPath.u8string();
+    });
+}


### PR DESCRIPTION
Log message failed to check existence of musxDocument before searching for staff name. Fixed the problem and added a test.

resolves #16.