### PR TITLE
Misc bug fixes

### DIFF
--- a/src/export/mss.cpp
+++ b/src/export/mss.cpp
@@ -735,7 +735,7 @@ static void processPart(const std::filesystem::path& outputPath, const DocumentP
         auto partName = part->getName(); // Utf8-encoded partname can contain non-ASCII characters 
         if (partName.empty()) {
             partName = "Part" + std::to_string(part->getCmper());
-            denigmaContext.logMessage(LogMsg() << "No part name found. Using " << partName << " for part name extension", LogSeverity::Warning);
+            denigmaContext.logMessage(LogMsg() << "No part name found. Using " << partName << " for part name extension");
         }
         auto currExtension = qualifiedOutputPath.extension();
         qualifiedOutputPath.replace_extension(utils::utf8ToPath(partName + currExtension.u8string()));

--- a/src/export/mss.cpp
+++ b/src/export/mss.cpp
@@ -455,7 +455,7 @@ void writeSmartShapePrefs(XmlElement& styleElement, const FinalePreferencesPtr& 
     setElementValue(styleElement, "hairpinHeight", prefs->smartShapeOptions->shortHairpinOpeningWidth / EVPU_PER_SPACE);
     setElementValue(styleElement, "hairpinContHeight", 0.5); // Hardcoded to a half space
     writeCategoryTextFontPref(styleElement, prefs, "hairpin", others::MarkingCategory::CategoryType::Dynamics);
-    writeLinePrefs(styleElement, "hairpin", prefs->smartShapeOptions->smartLineWidth, prefs->smartShapeOptions->smartDashOn, prefs->smartShapeOptions->smartDashOff);
+    writeLinePrefs(styleElement, "hairpin", prefs->smartShapeOptions->crescLineWidth, prefs->smartShapeOptions->smartDashOn, prefs->smartShapeOptions->smartDashOff);
 
     // Slur-related settings
     setElementValue(styleElement, "slurEndWidth", prefs->smartShapeOptions->smartSlurTipWidth / EVPU_PER_SPACE);
@@ -707,7 +707,7 @@ void writeMarkingPrefs(XmlElement& styleElement, const FinalePreferencesPtr& pre
     writeCategoryTextFontPref(styleElement, prefs, "metronome", CategoryType::TempoMarks);
     setElementValue(styleElement, "translatorFontFace", textBlockFont->getName());
     writeCategoryTextFontPref(styleElement, prefs, "systemText", CategoryType::ExpressiveText);
-    writeCategoryTextFontPref(styleElement, prefs, "staffText", CategoryType::ExpressiveText);
+    writeCategoryTextFontPref(styleElement, prefs, "staffText", CategoryType::TechniqueText);
     writeCategoryTextFontPref(styleElement, prefs, "rehearsalMark", CategoryType::RehearsalMarks);
     writeDefaultFontPref(styleElement, prefs, "repeatLeft", FontType::Repeat);
     writeDefaultFontPref(styleElement, prefs, "repeatRight", FontType::Repeat);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -163,7 +163,7 @@ int _MAIN(int argc, arg_char* argv[])
         }
         std::filesystem::path inputDir = inputFilePattern.parent_path();
         bool inputIsOneFile = std::filesystem::is_regular_file(inputFilePattern);        
-        if (!inputIsOneFile && !rawInputPattern.has_filename() && !denigmaContext.logFilePath.has_value()) {
+        if (!inputIsOneFile && !isSpecificFile && !denigmaContext.logFilePath.has_value()) {
             denigmaContext.logFilePath = "";
         }
         denigmaContext.startLogging(inputDir, argc, argv);

--- a/src/massage/musicxml.cpp
+++ b/src/massage/musicxml.cpp
@@ -295,7 +295,8 @@ static void massageXmlWithFinaleDocument(pugi::xml_node xmlMeasure,
     auto gfHold = context->musxDocument->getDetails()->get<details::GFrameHold>(context->musxPartId, staff->getCmper(), measure);
     if (gfHold) {
         pugi::xml_node nextNote;
-        gfHold->iterateEntries([&](const std::shared_ptr<const Entry>& entry) -> bool {
+        gfHold->iterateEntries([&](const std::shared_ptr<const EntryInfo>& entryInfo) -> bool {
+            auto entry = entryInfo->getEntry();
             if (entry->isHidden) { // Dolet does not create note elements for invisible entries
                 return true;
             }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,7 +73,7 @@ if(denigma_BUILD_TESTING)
     gtest_discover_tests(denigma_tests
         DISCOVERY_TIMEOUT 60 # Set timeout to 60 seconds
         PROPERTIES
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests/data
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/data
             ENVIRONMENT "GTEST_COLOR=1"
         EXTRA_ARGS --gtest_color=yes
     )

--- a/tests/data/inputs/reference/notAscii-其れ.mss
+++ b/tests/data/inputs/reference/notAscii-其れ.mss
@@ -215,7 +215,7 @@
         <staffTextFontFace>Times New Roman</staffTextFontFace>
         <staffTextFontSize>10</staffTextFontSize>
         <staffTextFontSpatiumDependent>1</staffTextFontSpatiumDependent>
-        <staffTextFontStyle>2</staffTextFontStyle>
+        <staffTextFontStyle>0</staffTextFontStyle>
         <rehearsalMarkFontFace>Times New Roman</rehearsalMarkFontFace>
         <rehearsalMarkFontSize>11.667</rehearsalMarkFontSize>
         <rehearsalMarkFontSpatiumDependent>1</rehearsalMarkFontSpatiumDependent>

--- a/tests/data/inputs/reference/notAscii-其れ.オボえ.mss
+++ b/tests/data/inputs/reference/notAscii-其れ.オボえ.mss
@@ -215,7 +215,7 @@
         <staffTextFontFace>Times New Roman</staffTextFontFace>
         <staffTextFontSize>10</staffTextFontSize>
         <staffTextFontSpatiumDependent>1</staffTextFontSpatiumDependent>
-        <staffTextFontStyle>2</staffTextFontStyle>
+        <staffTextFontStyle>0</staffTextFontStyle>
         <rehearsalMarkFontFace>Times New Roman</rehearsalMarkFontFace>
         <rehearsalMarkFontSize>11.667</rehearsalMarkFontSize>
         <rehearsalMarkFontSpatiumDependent>1</rehearsalMarkFontSpatiumDependent>

--- a/tests/test_logging.cpp
+++ b/tests/test_logging.cpp
@@ -29,6 +29,20 @@
 
 using namespace denigma;
 
+TEST(Logging, SingleFileNoLog)
+{
+    setupTestDataPaths();
+    std::string inputFile = "notAscii-其れ";
+    std::filesystem::path inputPath;
+    copyInputToOutput(inputFile + ".musx", inputPath);
+    ArgList args = { DENIGMA_NAME, "export", inputPath.u8string() };
+    checkStderr({ "Processing", inputPath.filename().u8string(), "Output", inputFile + ".enigmaxml" }, [&]() {
+        EXPECT_EQ(denigmaTestMain(args.argc(), args.argv()), 0) << "create from " << inputPath.u8string();
+    });
+    auto logPath = inputPath.parent_path() / (std::string(DENIGMA_NAME) + "-logs");
+    EXPECT_FALSE(std::filesystem::exists(logPath)) << "no log file should have been created";
+}
+
 TEST(Logging, InPlace)
 {
     setupTestDataPaths();
@@ -74,4 +88,46 @@ TEST(Logging, SpecificFile)
         auto logPath = inputPath.parent_path() / "logs";
         assertStringsInFile({ "Processing", inputPath.filename().u8string(), "Output", inputFile + ".enigmaxml", inputFile + ".mss" }, logPath, ".log");
     }
+}
+
+TEST(Logging, NonExistentFile)
+{
+    setupTestDataPaths();
+    auto inputPath = getOutputPath() / "doesntExist.musx";
+    ArgList args1 = { DENIGMA_NAME, "export", inputPath.u8string() };
+    checkStderr({ "does not exist or is not a file or directory", inputPath.filename().u8string() }, [&]() {
+        EXPECT_NE(denigmaTestMain(args1.argc(), args1.argv()), 0) << "create from " << inputPath.u8string();
+    });
+    auto logPath = inputPath.parent_path() / (std::string(DENIGMA_NAME) + "-logs");
+    EXPECT_FALSE(std::filesystem::exists(logPath)) << "no log file should have been created";
+}
+
+TEST(Logging, PatternFile)
+{
+    setupTestDataPaths();
+    std::filesystem::path inputPath;
+    copyInputToOutput("notAscii-其れ.musx", inputPath);
+    inputPath = getOutputPath() / "*.musx";
+    ArgList args1 = { DENIGMA_NAME, "export", inputPath.u8string() };
+    checkStderr("", [&]() {
+        EXPECT_EQ(denigmaTestMain(args1.argc(), args1.argv()), 0) << "create from " << inputPath.u8string();
+    });
+    auto logPath = inputPath.parent_path() / (std::string(DENIGMA_NAME) + "-logs");
+    EXPECT_TRUE(std::filesystem::exists(logPath)) << "log file should have been created";
+    assertStringsInFile({ "Processing", "notAscii-其れ.musx", "Output", "notAscii-其れ.enigmaxml" }, logPath, ".log");
+}
+
+TEST(Logging, Directory)
+{
+    setupTestDataPaths();
+    std::filesystem::path inputPath;
+    copyInputToOutput("notAscii-其れ.musx", inputPath);
+    inputPath = getOutputPath();
+    ArgList args1 = { DENIGMA_NAME, "export", inputPath.u8string() };
+    checkStderr("", [&]() {
+        EXPECT_EQ(denigmaTestMain(args1.argc(), args1.argv()), 0) << "create from " << inputPath.u8string();
+    });
+    auto logPath = inputPath / (std::string(DENIGMA_NAME) + "-logs");
+    EXPECT_TRUE(std::filesystem::exists(logPath)) << "log file should have been created";
+    assertStringsInFile({ "Processing", "notAscii-其れ.musx", "Output", "notAscii-其れ.enigmaxml" }, logPath, ".log");
 }


### PR DESCRIPTION
- refactoring
- fix small bugs in `.mss` export of hairpin line thickness, technique text font, and page printable width
- fix bug that prevented default log file when the input was a directory
