### PR TITLE
Implement cue-layer option

### DIFF
--- a/src/denigma.cpp
+++ b/src/denigma.cpp
@@ -126,6 +126,19 @@ std::vector<const arg_char*> DenigmaContext::parseOptions(int argc, arg_char* ar
             verbose = true;
         } else if (next == _ARG("--no-validate")) {
             noValidate = true;
+        } else if (next == _ARG("--cue-layer")) {
+            const std::string layerValue = std::string(_ARG_CONV(getNextArg()));
+            if (layerValue.empty()) {
+                throw std::invalid_argument("Missing value for --cue-layer");
+            }
+            try {
+                cueLayer = std::stoi(layerValue);
+            } catch (...) {
+                throw std::invalid_argument("Invalid value for --cue-layer: " + layerValue + " (must be 1..4)");
+            }
+            if (*cueLayer < 1 || *cueLayer > 4) {
+                throw std::invalid_argument("Invalid value for --cue-layer: " + layerValue + " (must be 1..4)");
+            }
         // Specific options for `massage` command
         } else if (next == _ARG("--finale-file")) {
             auto option = getNextArg();

--- a/src/denigma.h
+++ b/src/denigma.h
@@ -190,6 +190,7 @@ public:
     bool verbose{};
     bool quiet{};
     bool noValidate{};
+    std::optional<int> cueLayer;
     std::optional<std::filesystem::path> excludeFolder;
     std::optional<std::string> partName;
     std::optional<std::filesystem::path> logFilePath;
@@ -203,7 +204,7 @@ public:
     bool fermataWholeRests{ true };
     std::optional<std::filesystem::path> finaleFilePath;
 
-    // Specic options for `export --mnx` command
+    // Specific options for `export --mnx` command
     std::optional<int> indentSpaces{ JSON_INDENT_SPACES };
     std::optional<std::filesystem::path> mnxSchemaPath;
     std::optional<std::string> mnxSchema;

--- a/src/export/export.cpp
+++ b/src/export/export.cpp
@@ -83,6 +83,7 @@ int ExportCommand::showHelpPage(const std::string_view& programName, const std::
     std::cout << indentSpaces << "Usage: " << fullCommand << " <input-pattern> [--output options]" << std::endl;
     std::cout << std::endl;
     std::cout << indentSpaces << "Specific options:" << std::endl;
+    std::cout << indentSpaces << "  --cue-layer <1..4>              Treat entries in this Finale layer as cue material." << std::endl;
     std::cout << indentSpaces << "  --mnx-schema [file-path]        Validate against this json schema file rather than the embedded one." << std::endl;
     std::cout << indentSpaces << "  --include-tempo-tool            Include tempo changes created with the Tempo Tool." << std::endl;
     std::cout << indentSpaces << "  --no-include-tempo-tool         Exclude tempo changes created with the Tempo Tool (default: exclude)." << std::endl;

--- a/src/export/mnx.cpp
+++ b/src/export/mnx.cpp
@@ -35,24 +35,66 @@ namespace mnxexp {
 void MnxMusxMapping::logMessage(LogMsg&& msg, LogSeverity severity)
 {
     std::string logEntry;
-    if (currStaff > 0 && currMeas > 0) {
+    if (current.staff > 0 && current.meas > 0) {
         std::string staffName = [&]() -> std::string {
             if (document) {
-                if (auto staff = others::StaffComposite::createCurrent(document, SCORE_PARTID, currStaff, currMeas, 0)) {
+                if (auto staff = others::StaffComposite::createCurrent(document, SCORE_PARTID, current.staff, current.meas, 0)) {
                     auto instName = staff->getFullInstrumentName();
                     if (!instName.empty()) return instName;
                 }
             }
-            return "Staff " + std::to_string(currStaff);
+            return "Staff " + std::to_string(current.staff);
         }();
 
         std::string v;
-        if (!voice.empty()) {
-            v = " " + voice;
+        if (!current.voice.empty()) {
+            v = " " + current.voice;
         }
-        logEntry += "[" + staffName + " m" + std::to_string(currMeas) + v + "] ";
+        logEntry += "[" + staffName + " m" + std::to_string(current.meas) + v + "] ";
     }
     denigmaContext->logMessage(LogMsg() << logEntry << msg.str(), severity);
+}
+
+void MnxMusxMapping::logDiscardedCueLayerFrame(LayerIndex layer)
+{
+    discardedCueFrames++;
+    logMessage(LogMsg() << "discarded cue material detected by --cue-layer in measure "
+        << current.meas << ", staff " << current.staff << ", layer " << (layer + 1)
+        << "; MNX does not currently support cues.");
+}
+
+void MnxMusxMapping::logDiscardedHeuristicCueHold()
+{
+    discardedCueFrames++;
+    logMessage(LogMsg() << "discarded cue material detected heuristically in measure "
+        << current.meas << ", staff " << current.staff
+        << "; MNX does not currently support cues.");
+}
+
+void MnxMusxMapping::setCurrentMeasureStaff(const MusxInstance<others::Measure>& musxMeasure, StaffCmper staffCmper)
+{
+    current.clear();
+    current.meas = musxMeasure->getCmper();
+    current.staff = staffCmper;
+    current.gfhold.emplace(musxMeasure->getDocument(), musxMeasure->getRequestedPartId(), staffCmper, musxMeasure->getCmper());
+    if (!*current.gfhold) {
+        return;
+    }
+
+    current.layerVoices = current.gfhold->calcVoices();
+    if (current.gfhold->calcIsCuesOnly()) {
+        current.cueDiscardPlan.discardWholeHold = true;
+        logDiscardedHeuristicCueHold();
+        return;
+    }
+
+    if (denigmaContext->cueLayer) {
+        const LayerIndex cueLayer = static_cast<LayerIndex>(*denigmaContext->cueLayer - 1);
+        if (auto entryFrame = current.gfhold->createEntryFrame(cueLayer); entryFrame && !entryFrame->getEntries().empty()) {
+            current.cueDiscardPlan.discardLayers.emplace(cueLayer);
+            logDiscardedCueLayerFrame(cueLayer);
+        }
+    }
 }
 
 std::optional<int> MnxMusxMapping::mnxPartStaffFromStaff(StaffCmper staff) const
@@ -197,6 +239,10 @@ void exportJson(const std::filesystem::path& outputPath, const CommandInputData&
     if (!denigmaContext.mnxSplitInstruments) {
         createLayouts(context); // must come after createParts
         createScores(context); // must come after createLayouts
+    }
+    if (context->discardedCueFrames > 0) {
+        denigmaContext.logMessage(LogMsg() << "discarded " << context->discardedCueFrames
+            << " cue frames because MNX does not currently support cues.");
     }
 
     if (!denigmaContext.noValidate) {

--- a/src/export/mnx.h
+++ b/src/export/mnx.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <filesystem>
+#include <map>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -102,27 +103,57 @@ struct MnxMusxMapping
     std::vector<musx::util::ArpeggioSpanCandidate> deferredArpeggios;
     std::unordered_set<std::string> deferredArpeggioKeys;
 
-    MeasCmper currMeas{};
-    StaffCmper currStaff{};
     std::optional<std::string> currSplitInstrumentUuid;
-    std::string voice;
     std::vector<StaffCmper> currPartStaves;
     std::unordered_set<EntryNumber> beamedEntries;
-    std::unordered_map<Cmper, MusxInstance<others::SmartShape>> ottavasApplicableInMeasure;
+    size_t discardedCueFrames{};
+
+    struct CueDiscardPlan {
+        bool discardWholeHold{};
+        std::unordered_set<LayerIndex> discardLayers;
+
+        bool skipsLayer(LayerIndex layer) const
+        {
+            return discardWholeHold || discardLayers.find(layer) != discardLayers.end();
+        }
+    };
+
+    struct CurrentMeasureStaff {
+        MeasCmper meas{};
+        StaffCmper staff{};
+        std::string voice;
+        std::optional<details::GFrameHoldContext> gfhold;
+        std::map<LayerIndex, int> layerVoices;
+        CueDiscardPlan cueDiscardPlan;
+        std::unordered_map<Cmper, MusxInstance<others::SmartShape>> ottavasApplicableInMeasure;
+
+        void clear()
+        {
+            meas = staff = 0;
+            voice.clear();
+            gfhold.reset();
+            layerVoices.clear();
+            cueDiscardPlan = {};
+            ottavasApplicableInMeasure.clear();
+        }
+    };
+
+    CurrentMeasureStaff current;
 
     std::optional<int> mnxPartStaffFromStaff(StaffCmper staff) const;
 
     void clearCounts()
     {
-        currMeas = currStaff = 0;
         currSplitInstrumentUuid.reset();
-        voice.clear();
         currPartStaves.clear();
         beamedEntries.clear();
-        ottavasApplicableInMeasure.clear();
+        current.clear();
     }
 
+    void setCurrentMeasureStaff(const MusxInstance<others::Measure>& musxMeasure, StaffCmper staffCmper);
     void logMessage(LogMsg&& msg, LogSeverity severity = LogSeverity::Info);
+    void logDiscardedHeuristicCueHold();
+    void logDiscardedCueLayerFrame(LayerIndex layer);
 };
 
 std::string mnxPartDisplayName(const MnxMusxMappingPtr& context, const std::string& partId);
@@ -195,8 +226,7 @@ void createParts(const MnxMusxMappingPtr& context);
 void createSequences(const MnxMusxMappingPtr& context,
     mnx::part::Measure& mnxMeasure,
     std::optional<int> mnxStaffNumber,
-    const MusxInstance<others::Measure>& musxMeasure,
-    StaffCmper staffCmper);
+    const MusxInstance<others::Measure>& musxMeasure);
 void finalizeJumpTies(const MnxMusxMappingPtr& context);
 
 void exportJson(const std::filesystem::path& outputPath, const CommandInputData& inputData, const DenigmaContext& denigmaContext);

--- a/src/export/mnx_markings.cpp
+++ b/src/export/mnx_markings.cpp
@@ -404,18 +404,18 @@ static bool appendDeferredArpeggioToPart(const MnxMusxMappingPtr& context,
     }
 
     auto savedPartStaves = context->currPartStaves;
-    auto savedMeas = context->currMeas;
-    auto savedStaff = context->currStaff;
+    auto savedMeas = context->current.meas;
+    auto savedStaff = context->current.staff;
     context->currPartStaves = partIt->second;
-    context->currMeas = candidate.sourceEntry.getMeasure();
-    context->currStaff = context->currPartStaves.front();
+    context->current.meas = candidate.sourceEntry.getMeasure();
+    context->current.staff = context->currPartStaves.front();
 
     const auto splitTopNote = findArpeggioBoundaryNoteInCurrentPart(context, candidate.topEntry, candidate.bottomEntry, true);
     const auto splitBottomNote = findArpeggioBoundaryNoteInCurrentPart(context, candidate.bottomEntry, candidate.topEntry, false);
 
     context->currPartStaves = savedPartStaves;
-    context->currMeas = savedMeas;
-    context->currStaff = savedStaff;
+    context->current.meas = savedMeas;
+    context->current.staff = savedStaff;
 
     if (!splitTopNote || !splitBottomNote) {
         return false;

--- a/src/export/mnx_parts.cpp
+++ b/src/export/mnx_parts.cpp
@@ -36,17 +36,16 @@ namespace mnxexp {
 static void createBeams(
     const MnxMusxMappingPtr& context,
     mnx::part::Measure mnxMeasure,
-    const MusxInstance<others::Measure>& musxMeasure,
-    StaffCmper staffCmper)
+    const MusxInstance<others::Measure>& musxMeasure)
 {
     const auto& musxDocument = musxMeasure->getDocument();
     const auto mnxMeasures = mnxMeasure.parent<mnx::Array<mnx::part::Measure>>();
     const auto partId = musxMeasure->getRequestedPartId();
-    if (auto gfhold = details::GFrameHoldContext(musxDocument, partId, staffCmper, musxMeasure->getCmper())) {
-        if (gfhold.calcIsCuesOnly()) {
+    if (context->current.gfhold) {
+        if (context->current.cueDiscardPlan.discardWholeHold) {
             return; // skip cues until MNX spec includes them
         }
-        gfhold.iterateEntries([&](const EntryInfoPtr& entryInfo) -> bool {
+        auto processEntry = [&](const EntryInfoPtr& entryInfo) -> bool {
             auto processBeam = [&](mnx::Array<mnx::part::Beam>&& mnxBeams, unsigned beamNumber, const EntryInfoPtr& firstInBeam, auto&& self) -> void {
                 assert(firstInBeam.calcLowestBeamStart(/*considerBeamOverBarlines*/true) <= beamNumber);
                 auto beam = mnxBeams.append();
@@ -106,7 +105,15 @@ static void createBeams(
                 processBeam(mnxMeasure.ensure_beams(), 1, entryInfo, processBeam);
             }
             return true;
-        });
+        };
+        for (const auto& [layer, _] : context->current.layerVoices) {
+            if (context->current.cueDiscardPlan.skipsLayer(layer)) {
+                continue;
+            }
+            if (auto entryFrame = context->current.gfhold->createEntryFrame(layer)) {
+                entryFrame->iterateEntries(processEntry);
+            }
+        }
     }
 }
 
@@ -163,10 +170,10 @@ static void createClefs(
     mnx::part::Measure& mnxMeasure,
     std::optional<int> mnxStaffNumber,
     const MusxInstance<others::Measure>& musxMeasure,
-    StaffCmper staffCmper,
     std::optional<ClefIndex>& prevClefIndex)
 {
     const auto& musxDocument = musxMeasure->getDocument();
+    const StaffCmper staffCmper = context->current.staff;
 
     auto addClef = [&](ClefIndex clefIndex, musx::util::Fraction location) {
         if (clefIndex == prevClefIndex) {
@@ -201,9 +208,10 @@ static void createClefs(
     }
 }
 
-static void processExpressions(const MnxMusxMappingPtr& context, const MusxInstance<others::Measure>& musxMeasure, StaffCmper staffCmper,
+static void processExpressions(const MnxMusxMappingPtr& context, const MusxInstance<others::Measure>& musxMeasure,
     mnx::part::Measure& mnxMeasure, std::optional<int> mnxStaffNumber)
 {
+    const StaffCmper staffCmper = context->current.staff;
     struct ExpressionAttachmentContext {
         EntryInfoPtr entryInfo;
         const EntryTarget* entryTarget{ nullptr };
@@ -319,9 +327,9 @@ static void processExpressions(const MnxMusxMappingPtr& context, const MusxInsta
 static void processSmartShapes(
     const MnxMusxMappingPtr& context,
     mnx::part::Measure mnxMeasure,
-    const MusxInstance<others::Measure>& musxMeasure,
-    StaffCmper staffCmper)
+    const MusxInstance<others::Measure>& musxMeasure)
 {
+    const StaffCmper staffCmper = context->current.staff;
     if (musxMeasure->hasSmartShape) {
         const auto assigns = context->document->getOthers()->getArray<others::SmartShapeMeasureAssign>(musxMeasure->getRequestedPartId(), musxMeasure->getCmper());
         for (const auto& assign : assigns) {
@@ -344,10 +352,11 @@ static void processSmartShapes(
     }
 }
 
-static void createOttavas(const MnxMusxMappingPtr& context, const MusxInstance<others::Measure>& musxMeasure, StaffCmper staffCmper,
+static void createOttavas(const MnxMusxMappingPtr& context, const MusxInstance<others::Measure>& musxMeasure,
     mnx::part::Measure& mnxMeasure, std::optional<int> mnxStaffNumber)
 {
-    context->ottavasApplicableInMeasure.clear();
+    const StaffCmper staffCmper = context->current.staff;
+    context->current.ottavasApplicableInMeasure.clear();
     if (musxMeasure->hasSmartShape) {
         auto shapeAssigns = context->document->getOthers()->getArray<others::SmartShapeMeasureAssign>(musxMeasure->getRequestedPartId(), musxMeasure->getCmper());
         for (const auto& asgn : shapeAssigns) {
@@ -361,7 +370,7 @@ static void createOttavas(const MnxMusxMappingPtr& context, const MusxInstance<o
                         case others::SmartShape::ShapeType::TwoOctaveUp:
                             break;
                     }
-                    context->ottavasApplicableInMeasure.emplace(shape->getCmper(), shape);
+                    context->current.ottavasApplicableInMeasure.emplace(shape->getCmper(), shape);
                     if (!asgn->centerShapeNum && shape->startTermSeg->endPoint->measId == musxMeasure->getCmper()) {
                         auto mnxOttava = mnxMeasure.ensure_ottavas().append(
                             enumConvert<mnx::OttavaAmount>(shape->shapeType),
@@ -420,16 +429,17 @@ static void createMeasures(const MnxMusxMappingPtr& context, mnx::Part& part)
         // create measures in one go, so that createBeams can add a beam to any measure
         mnxMeasures.append();
     }
+    size_t measureIndex = 0;
     for (const auto& musxMeasure : musxMeasures) {
-        auto mnxMeasure = mnxMeasures.at(context->currMeas++);
+        auto mnxMeasure = mnxMeasures.at(measureIndex++);
         if (const auto partId = part.id()) {
             mnxMeasure.set_id(partId.value() + "." + calcGlobalMeasureId(musxMeasure->getCmper()));
         }
         for (size_t x = 0; x < context->currPartStaves.size(); x++) {
-            context->currStaff = context->currPartStaves[x];
+            const StaffCmper staffCmper = context->currPartStaves[x];
             std::optional<int> staffNumber = (context->currPartStaves.size() > 1) ? std::optional<int>(int(x) + 1) : std::nullopt;
             if (context->currSplitInstrumentUuid) {
-                const auto& instInfo = context->document->getInstrumentForStaff(context->currStaff);
+                const auto& instInfo = context->document->getInstrumentForStaff(staffCmper);
                 const auto identity = instInfo.getInstrumentIdentityAt(MusicPoint(musxMeasure->getCmper(), musx::util::Fraction{}));
                 if (musxMeasure->getCmper() == 1) {
                     const auto musxStaff = findCompositeForIdentity(instInfo, identity);
@@ -439,17 +449,18 @@ static void createMeasures(const MnxMusxMappingPtr& context, mnx::Part& part)
                     continue;
                 }
             } else if (musxMeasure->getCmper() == 1) {
-                const auto musxStaff = others::StaffComposite::createCurrent(musxDocument, musxMeasure->getRequestedPartId(), context->currStaff, 1, 0);
+                const auto musxStaff = others::StaffComposite::createCurrent(musxDocument, musxMeasure->getRequestedPartId(), staffCmper, 1, 0);
                 prevClefs[x] = createClef(context, mnxMeasure, staffNumber, musxStaff->calcClefIndex(/*forWrittenPitch*/ true), 0, musxStaff);
             }
-            createBeams(context, mnxMeasure, musxMeasure, context->currPartStaves[x]);
-            createClefs(context, part, mnxMeasure, staffNumber, musxMeasure, context->currPartStaves[x], prevClefs[x]);
+            context->setCurrentMeasureStaff(musxMeasure, staffCmper);
+            createBeams(context, mnxMeasure, musxMeasure);
+            createClefs(context, part, mnxMeasure, staffNumber, musxMeasure, prevClefs[x]);
             // ottaves must be created before sequences, so that the ottava octaves can be correctly calculated for events
-            createOttavas(context, musxMeasure, context->currPartStaves[x], mnxMeasure, staffNumber);
-            createSequences(context, mnxMeasure, staffNumber, musxMeasure, context->currPartStaves[x]);
+            createOttavas(context, musxMeasure, mnxMeasure, staffNumber);
+            createSequences(context, mnxMeasure, staffNumber, musxMeasure);
             // the following must come after sequences, in case we need to attach to events (e.g., fermatas);
-            processExpressions(context, musxMeasure, context->currPartStaves[x], mnxMeasure, staffNumber);
-            processSmartShapes(context, mnxMeasure, musxMeasure, context->currPartStaves[x]);
+            processExpressions(context, musxMeasure, mnxMeasure, staffNumber);
+            processSmartShapes(context, mnxMeasure, musxMeasure);
         }
     }
     context->clearCounts();

--- a/src/export/mnx_sequences.cpp
+++ b/src/export/mnx_sequences.cpp
@@ -331,7 +331,7 @@ static void processArticulations(const MnxMusxMappingPtr& context, mnx::sequence
 mnx::sequence::Note createNormalNote(const MnxMusxMappingPtr& context, mnx::sequence::Event& mnxEvent, const NoteInfoPtr& musxNote)
 {
     auto [noteName, octave, alteration, _] = musxNote.calcNotePropertiesConcert();
-    for (const auto& it : context->ottavasApplicableInMeasure) {
+    for (const auto& it : context->current.ottavasApplicableInMeasure) {
         auto shape = it.second;
         if (shape->calcAppliesTo(musxNote.getEntryInfo())) {
             // if the note is a tie continuation, the ottava has to apply to the original note
@@ -650,7 +650,7 @@ static EntryInfoPtr::InterpretedIterator addEntryToContent(const MnxMusxMappingP
             elapsedInSequence = currElapsedDuration;
         }
         if (context->currSplitInstrumentUuid) {
-            const auto& instInfo = context->document->getInstrumentForStaff(context->currStaff);
+            const auto& instInfo = context->document->getInstrumentForStaff(context->current.staff);
             const auto identity = instInfo.getInstrumentIdentityAt(MusicPoint(entryInfo.getMeasure(), currElapsedDuration));
             if (identity.instUuid != context->currSplitInstrumentUuid.value()) {
                 context->logMessage(LogMsg() << "Entry " << entry->getEntryNumber()
@@ -726,22 +726,21 @@ static EntryInfoPtr::InterpretedIterator addEntryToContent(const MnxMusxMappingP
 void createSequences(const MnxMusxMappingPtr& context,
     mnx::part::Measure& mnxMeasure,
     std::optional<int> mnxStaffNumber,
-    const MusxInstance<others::Measure>& musxMeasure,
-    StaffCmper staffCmper)
+    const MusxInstance<others::Measure>& musxMeasure)
 {
-    auto gfhold = details::GFrameHoldContext(musxMeasure->getDocument(), musxMeasure->getRequestedPartId(), staffCmper, musxMeasure->getCmper());
-    if (!gfhold) {
+    if (!context->current.gfhold || !*context->current.gfhold) {
         return; // nothing to do
     }
-    if (gfhold.calcIsCuesOnly()) {
-        context->logMessage(LogMsg() << " skipping cues until MNX committee decides how to handle them.", LogSeverity::Verbose);
+    if (context->current.cueDiscardPlan.discardWholeHold) {
         return;
     }
-    const auto measureDuration = musxMeasure->calcDuration(staffCmper);
-    const std::map<LayerIndex, int> layerVoices = gfhold.calcVoices();
-    for (const auto& [layer, numV2] : layerVoices) {
+    const auto measureDuration = musxMeasure->calcDuration(context->current.staff);
+    for (const auto& [layer, numV2] : context->current.layerVoices) {
+        if (context->current.cueDiscardPlan.skipsLayer(layer)) {
+            continue;
+        }
         const int maxVoices = numV2 ? 2 : 1;
-        if (auto entryFrame = gfhold.createEntryFrame(layer)) {
+        if (auto entryFrame = context->current.gfhold->createEntryFrame(layer)) {
             const bool usesV1V2 = numV2 && entryFrame->getFirstInterpretedIterator(2); // ignore entries the iterator will skip
             auto entries = entryFrame->getEntries();
             if (!entries.empty()) {
@@ -751,12 +750,12 @@ void createSequences(const MnxMusxMappingPtr& context,
                         if (mnxStaffNumber) {
                             sequence.set_staff(mnxStaffNumber.value());
                         }
-                        context->voice = calcVoice(mnxStaffNumber.value_or(1), layer, voice);
-                        sequence.set_voice(context->voice);
+                        context->current.voice = calcVoice(mnxStaffNumber.value_or(1), layer, voice);
+                        sequence.set_voice(context->current.voice);
                         auto elapsedInVoice = musx::util::Fraction(0);
                         addEntryToContent(context, sequence.content(), firstEntry, elapsedInVoice, usesV1V2, false);
                         appendMeasureRemainderSpaces(sequence.content(), elapsedInVoice, measureDuration);
-                        context->voice.clear();
+                        context->current.voice.clear();
                     }
                 }
             }

--- a/tests/mnx/test_parts.cpp
+++ b/tests/mnx/test_parts.cpp
@@ -193,3 +193,17 @@ TEST(MnxParts, PartiallyHiddenCue)
         EXPECT_EQ(denigmaTestMain(args.argc(), args.argv()), 0) << "export to mnx: " << pathString(inputPath);
     });
 }
+
+TEST(MnxParts, CueLayer)
+{
+    setupTestDataPaths();
+    std::filesystem::path inputPath;
+    copyInputToOutput("forced_bass_clef.musx", inputPath);
+    ArgList args = { DENIGMA_NAME, "export", pathString(inputPath), "--mnx", "--cue-layer", "1", "--no-validate" };
+    checkStderr(std::vector<std::string>{
+        "discarded cue material detected by --cue-layer in measure 2, staff 1, layer 1; MNX does not currently support cues.",
+        "discarded 1 cue frames because MNX does not currently support cues."
+    }, [&]() {
+        EXPECT_EQ(denigmaTestMain(args.argc(), args.argv()), 0) << "export to mnx with cue layer: " << pathString(inputPath);
+    });
+}

--- a/tests/test_options.cpp
+++ b/tests/test_options.cpp
@@ -102,6 +102,12 @@ TEST(Options, IncorrectOptions)
             EXPECT_NE(denigmaTestMain(args.argc(), args.argv()), 0) << "svg scale conflicts with page scale";
         });
     }
+    {
+        ArgList args = { DENIGMA_NAME, "--testing", "export", "input.musx", "--cue-layer", "5", "--mnx" };
+        checkStderr("Invalid value for --cue-layer: 5 (must be 1..4)", [&]() {
+            EXPECT_NE(denigmaTestMain(args.argc(), args.argv()), 0) << "invalid cue layer";
+        });
+    }
 }
 
 TEST(Options, ParseOptions)
@@ -220,6 +226,17 @@ TEST(Options, ParseOptions)
         EXPECT_EQ(pathString(std::filesystem::path(newArgs[2])), "--svg");
         EXPECT_FALSE(ctx.svgUsePageScale);
         EXPECT_DOUBLE_EQ(ctx.svgScale, 1.25);
+    }
+    {
+        static const std::string fileName = "notAscii-其れ";
+        ArgList args = { DENIGMA_NAME, "--testing", "export", fileName + ".musx", "--mnx", "--cue-layer", "4" };
+        DenigmaContext ctx(DENIGMA_NAME);
+        auto newArgs = ctx.parseOptions(args.argc(), args.argv());
+        EXPECT_EQ(newArgs.size(), 3);
+        EXPECT_EQ(pathString(std::filesystem::path(newArgs[1])), fileName + ".musx");
+        EXPECT_EQ(pathString(std::filesystem::path(newArgs[2])), "--mnx");
+        ASSERT_TRUE(ctx.cueLayer.has_value());
+        EXPECT_EQ(ctx.cueLayer.value(), 4);
     }
     {
         static const std::string fileName = "notAscii-其れ";


### PR DESCRIPTION
Provide the `--cue-layer` options that specifies a layer that is always used for cues. Any frames in that layer are converted as cues.