### PR TITLE
Refactor Finale Options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,6 +319,7 @@ add_executable(denigma
     src/main.cpp
     src/about.cpp
     src/denigma.cpp
+    src/finale_options.cpp
     src/classify/articulations.cpp
     src/classify/clefs.cpp
     src/classify/dynamics.cpp

--- a/src/export/mnx.cpp
+++ b/src/export/mnx.cpp
@@ -226,7 +226,6 @@ void exportJson(const std::filesystem::path& outputPath, const CommandInputData&
     auto context = std::make_shared<MnxMusxMapping>(denigmaContext, document);
     context->mnxDocument = std::make_unique<mnx::Document>();
     context->musxParts = others::PartDefinition::getInUserOrder(document);
-    context->clefOptions = getDocOptions<options::ClefOptions>(document, "clef options");
 
     createMappings(context);   // map repeat text, text exprs, articulations, etc. to semantic values
 

--- a/src/export/mnx.h
+++ b/src/export/mnx.h
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include "denigma.h"
+#include "finale_options.h"
 #include "musx/musx.h"
 #include "mnxdom.h"
 
@@ -73,14 +74,13 @@ using json = nlohmann::ordered_json;
 struct MnxMusxMapping
 {
     MnxMusxMapping(const DenigmaContext& context, const DocumentPtr& doc)
-        : denigmaContext(&context), document(doc), mnxDocument(), musxParts(doc, SCORE_PARTID) {}
+        : denigmaContext(&context), document(doc), finaleOptions(loadFinaleOptions(doc)), mnxDocument(), musxParts(doc, SCORE_PARTID) {}
 
     const DenigmaContext* denigmaContext;
     musx::dom::DocumentPtr document;
+    FinaleOptions finaleOptions;
     std::unique_ptr<mnx::Document> mnxDocument;
     MusxInstanceList<others::PartDefinition> musxParts;
-
-    MusxInstance<options::ClefOptions> clefOptions;
 
     std::unordered_map<std::string, std::vector<StaffCmper>> part2Inst;
     std::unordered_map<StaffCmper, std::string> inst2Part;

--- a/src/export/mnx_global.cpp
+++ b/src/export/mnx_global.cpp
@@ -291,8 +291,8 @@ static void createGlobalMeasures(const MnxMusxMappingPtr& context)
     const auto& musxDocument = context->document;
 
     // Retrieve the linked parts in order.
-    auto musxMeasures = musxDocument->getOthers()->getArray<others::Measure>(SCORE_PARTID);
-    auto musxBarlineOptions = context->finaleOptions.barlineOptions;
+    const auto musxMeasures = musxDocument->getOthers()->getArray<others::Measure>(SCORE_PARTID);
+    const auto musxBarlineOptions = context->finaleOptions.barlineOptions;
     std::optional<int> prevKeyFifths;
     MusxInstance<TimeSignature> prevTimeSig;
     for (const auto& musxMeasure : musxMeasures) {

--- a/src/export/mnx_global.cpp
+++ b/src/export/mnx_global.cpp
@@ -292,7 +292,7 @@ static void createGlobalMeasures(const MnxMusxMappingPtr& context)
 
     // Retrieve the linked parts in order.
     auto musxMeasures = musxDocument->getOthers()->getArray<others::Measure>(SCORE_PARTID);
-    auto musxBarlineOptions = musxDocument->getOptions()->get<options::BarlineOptions>();
+    auto musxBarlineOptions = context->finaleOptions.barlineOptions;
     std::optional<int> prevKeyFifths;
     MusxInstance<TimeSignature> prevTimeSig;
     for (const auto& musxMeasure : musxMeasures) {

--- a/src/export/mnx_parts.cpp
+++ b/src/export/mnx_parts.cpp
@@ -129,7 +129,7 @@ static std::optional<ClefIndex> createClef(
         context->logMessage(LogMsg() << "invalid or unmapped staff passed to createClef", LogSeverity::Warning);
         return std::nullopt;
     }
-    const auto& musxClef = context->clefOptions->getClefDef(clefIndex);
+    const auto& musxClef = context->finaleOptions.clefOptions->getClefDef(clefIndex);
     const auto clef = classify::classifyClef(musxClef, musxStaff);
     std::optional<mnx::ClefSign> clefSign;
     if (clef && !clef.isBlank && std::abs(clef.octave) <= 3) {
@@ -503,7 +503,7 @@ static void populatePartMetadata(
     const InstrumentInfo& instInfo,
     const MusxInstance<others::StaffComposite>& staff)
 {
-    auto musxMiscOptions = context->document->getOptions()->get<options::MiscOptions>();
+    auto musxMiscOptions = context->finaleOptions.miscOptions;
 
     part.set_id(id);
     auto fullName = staff->getFullInstrumentName(EnigmaString::AccidentalStyle::Unicode);

--- a/src/export/mnx_parts.cpp
+++ b/src/export/mnx_parts.cpp
@@ -503,21 +503,21 @@ static void populatePartMetadata(
     const InstrumentInfo& instInfo,
     const MusxInstance<others::StaffComposite>& staff)
 {
-    auto musxMiscOptions = context->finaleOptions.miscOptions;
+    const auto musxMiscOptions = context->finaleOptions.miscOptions;
 
     part.set_id(id);
-    auto fullName = staff->getFullInstrumentName(EnigmaString::AccidentalStyle::Unicode);
+    const auto fullName = staff->getFullInstrumentName(EnigmaString::AccidentalStyle::Unicode);
     if (!fullName.empty()) {
         part.set_name(trimNewLineFromString(fullName));
     }
-    auto abrvName = staff->getAbbreviatedInstrumentName(EnigmaString::AccidentalStyle::Unicode);
+    const auto abrvName = staff->getAbbreviatedInstrumentName(EnigmaString::AccidentalStyle::Unicode);
     if (!abrvName.empty()) {
         part.set_shortName(trimNewLineFromString(abrvName));
     }
     if (instInfo.staves.size() > 1) {
         part.set_staves(int(instInfo.staves.size()));
     }
-    auto [transpositionDisp, transpositionAlt] = staff->calcTranspositionInterval();
+    const auto [transpositionDisp, transpositionAlt] = staff->calcTranspositionInterval();
     if (transpositionDisp || transpositionAlt) {
         auto transposition = part.ensure_transposition(
             mnx::Interval::make(transpositionDisp,

--- a/src/export/mnx_sequences.cpp
+++ b/src/export/mnx_sequences.cpp
@@ -596,7 +596,7 @@ static EntryInfoPtr::InterpretedIterator addEntryToContent(const MnxMusxMappingP
     musx::util::Fraction& elapsedInSequence, bool hasVoice1Voice2,
     bool inGrace, const std::optional<size_t>& tupletIndex = std::nullopt, bool inTremolo = false)
 {
-    auto musxGraceOptions = context->finaleOptions.graceOptions;
+    const auto musxGraceOptions = context->finaleOptions.graceOptions;
     auto next = firstEntryInfo;
     while (next) {
         if (tupletIndex) {
@@ -608,8 +608,8 @@ static EntryInfoPtr::InterpretedIterator addEntryToContent(const MnxMusxMappingP
             }
         }
 
-        auto entryInfo = next.getEntryInfo();
-        auto entry = entryInfo->getEntry();
+        const auto entryInfo = next.getEntryInfo();
+        const auto entry = entryInfo->getEntry();
         if (inGrace && !entry->graceNote) {
             return next;
         } else if (!inGrace && entry->graceNote) {

--- a/src/export/mnx_sequences.cpp
+++ b/src/export/mnx_sequences.cpp
@@ -596,7 +596,7 @@ static EntryInfoPtr::InterpretedIterator addEntryToContent(const MnxMusxMappingP
     musx::util::Fraction& elapsedInSequence, bool hasVoice1Voice2,
     bool inGrace, const std::optional<size_t>& tupletIndex = std::nullopt, bool inTremolo = false)
 {
-    auto musxGraceOptions = context->document->getOptions()->get<options::GraceNoteOptions>();
+    auto musxGraceOptions = context->finaleOptions.graceOptions;
     auto next = firstEntryInfo;
     while (next) {
         if (tupletIndex) {

--- a/src/export/mss.cpp
+++ b/src/export/mss.cpp
@@ -32,6 +32,7 @@
 
 #include "denigma.h"
 
+#include "finale_options.h"
 #include "mss.h"
 #include "musx/musx.h"
 #include "pugixml.hpp"
@@ -126,62 +127,31 @@ static bool fontIsEngravingWithMappedLegacy(const FontInfo* fontInfo)
     return mappedSmuflFontName(fontInfo->getName()).has_value();
 }
 
-// Finale preferences:
-struct FinalePreferences
+// MSS preferences:
+struct MssPreferences : public FinaleOptions
 {
-    FinalePreferences(const DenigmaContext& context)
-        : denigmaContext(&context) {}
-
     const DenigmaContext* denigmaContext;
     DocumentPtr document;
     Cmper forPartId{};
     //
-    MusxInstance<FontInfo> defaultMusicFont;
     std::string musicFontName;
     double spatiumScaling{};
     //
-    MusxInstance<options::AccidentalOptions> accidentalOptions;
-    MusxInstance<options::AlternateNotationOptions> alternateNotationOptions;
-    MusxInstance<options::AugmentationDotOptions> augDotOptions;
-    MusxInstance<options::BarlineOptions> barlineOptions;
-    MusxInstance<options::BeamOptions> beamOptions;
-    MusxInstance<options::ChordOptions> chordOptions;
-    MusxInstance<options::ClefOptions> clefOptions;
-    MusxInstance<options::FlagOptions> flagOptions;
-    MusxInstance<options::GraceNoteOptions> graceOptions;
-    MusxInstance<options::KeySignatureOptions> keyOptions;
-    MusxInstance<options::LineCurveOptions> lineCurveOptions;
-    MusxInstance<options::MiscOptions> miscOptions;
-    MusxInstance<options::MusicSymbolOptions> musicSymbolOptions;
-    MusxInstance<options::MultimeasureRestOptions> mmRestOptions;
-    MusxInstance<options::MusicSpacingOptions> musicSpacing;
     MusxInstance<options::PageFormatOptions::PageFormat> pageFormat;
-    MusxInstance<options::PianoBraceBracketOptions> braceOptions;
-    MusxInstance<options::RepeatOptions> repeatOptions;
-    MusxInstance<options::SmartShapeOptions> smartShapeOptions;
-    MusxInstance<options::StaffOptions> staffOptions;
-    MusxInstance<options::StemOptions> stemOptions;
-    MusxInstance<options::TieOptions> tieOptions;
-    MusxInstance<options::TimeSignatureOptions> timeOptions;
-    MusxInstance<options::TupletOptions> tupletOptions;
-    //
     MusxInstance<others::LayerAttributes> layerOneAttributes;
     MusxInstance<others::MeasureNumberRegion::ScorePartData> measNumScorePart;
     MusxInstance<others::PartGlobals> partGlobals;
 };
-using FinalePreferencesPtr = std::shared_ptr<FinalePreferences>;
+using MssPreferencesPtr = std::shared_ptr<MssPreferences>;
 
-static FinalePreferencesPtr getCurrentPrefs(const DocumentPtr& document, Cmper forPartId, const DenigmaContext& denigmaContext)
+static MssPreferencesPtr getCurrentPrefs(const DocumentPtr& document, const FinaleOptions& finaleOptions, Cmper forPartId, const DenigmaContext& denigmaContext)
 {
-    auto retval = std::make_shared<FinalePreferences>(denigmaContext);
+    auto retval = std::make_shared<MssPreferences>();
+    static_cast<FinaleOptions&>(*retval) = finaleOptions;
+    retval->denigmaContext = &denigmaContext;
     retval->document = document;
     retval->forPartId = forPartId;
 
-    auto fontOptions = getDocOptions<options::FontOptions>(document, "font");
-    retval->defaultMusicFont = fontOptions->getFontInfo(options::FontOptions::FontType::Music);
-    if (!retval->defaultMusicFont) {
-        throw std::invalid_argument("document contains no information for the default music font.");
-    }
     retval->musicFontName = [&]() -> std::string {
         std::string fontName = retval->defaultMusicFont->getName();
         if (retval->defaultMusicFont->calcIsSMuFL()) {
@@ -192,32 +162,7 @@ static FinalePreferencesPtr getCurrentPrefs(const DocumentPtr& document, Cmper f
         }
         return {};
     }();
-    //
-    retval->accidentalOptions = getDocOptions<options::AccidentalOptions>(document, "accidental");
-    retval->alternateNotationOptions = getDocOptions<options::AlternateNotationOptions>(document, "alternate notation");
-    retval->augDotOptions = getDocOptions<options::AugmentationDotOptions>(document, "augmentation dot");
-    retval->barlineOptions = getDocOptions<options::BarlineOptions>(document, "barline");
-    retval->beamOptions = getDocOptions<options::BeamOptions>(document, "beam");
-    retval->chordOptions = getDocOptions<options::ChordOptions>(document, "chord");
-    retval->clefOptions = getDocOptions<options::ClefOptions>(document, "clef");
-    retval->flagOptions = getDocOptions<options::FlagOptions>(document, "flag");
-    retval->graceOptions = getDocOptions<options::GraceNoteOptions>(document, "grace note");
-    retval->keyOptions = getDocOptions<options::KeySignatureOptions>(document, "key signature");
-    retval->lineCurveOptions = getDocOptions<options::LineCurveOptions>(document, "lines & curves");
-    retval->miscOptions = getDocOptions<options::MiscOptions>(document, "miscellaneous");
-    retval->musicSymbolOptions = getDocOptions<options::MusicSymbolOptions>(document, "music symbol");
-    retval->mmRestOptions = getDocOptions<options::MultimeasureRestOptions>(document, "multimeasure rest");
-    retval->musicSpacing = getDocOptions<options::MusicSpacingOptions>(document, "music spacing");
-    auto pageFormatOptions = getDocOptions<options::PageFormatOptions>(document, "page format");
-    retval->pageFormat = pageFormatOptions->calcPageFormatForPart(forPartId);
-    retval->braceOptions = getDocOptions<options::PianoBraceBracketOptions>(document, "piano braces & brackets");
-    retval->repeatOptions = getDocOptions<options::RepeatOptions>(document, "repeat");
-    retval->smartShapeOptions = getDocOptions<options::SmartShapeOptions>(document, "smart shape");
-    retval->staffOptions = getDocOptions<options::StaffOptions>(document, "staff");
-    retval->stemOptions = getDocOptions<options::StemOptions>(document, "stem");
-    retval->tieOptions = getDocOptions<options::TieOptions>(document, "tie");
-    retval->timeOptions = getDocOptions<options::TimeSignatureOptions>(document, "time signature");
-    retval->tupletOptions = getDocOptions<options::TupletOptions>(document, "tuplet");
+    retval->pageFormat = retval->pageFormatOptions->calcPageFormatForPart(forPartId);
     //
     retval->layerOneAttributes = document->getOthers()->get<others::LayerAttributes>(forPartId, 0);
     if (!retval->layerOneAttributes) {
@@ -233,8 +178,8 @@ static FinalePreferencesPtr getCurrentPrefs(const DocumentPtr& document, Cmper f
         }
     }
     retval->partGlobals = document->getOthers()->get<others::PartGlobals>(forPartId, MUSX_GLOBALS_CMPER);
-    if (!retval->layerOneAttributes) {
-        throw std::invalid_argument("document contains no options for Layer 1");
+    if (!retval->partGlobals) {
+        throw std::invalid_argument("document contains no part globals");
     }
     retval->spatiumScaling = retval->pageFormat->calcCombinedSystemScaling().toDouble();
 
@@ -345,16 +290,16 @@ static uint16_t museFontEfx(const FontInfo* fontInfo)
     return retval;
 }
 
-static double museMagVal(const FinalePreferencesPtr& prefs, const options::FontOptions::FontType type)
+static double museMagVal(const MssPreferencesPtr& prefs, const options::FontOptions::FontType type)
 {
-    auto fontPrefs = options::FontOptions::getFontInfo(prefs->document, type);
+    auto fontPrefs = prefs->fontOptions->getFontInfo(type);
     if (fontPrefs->getName() == prefs->defaultMusicFont->getName()) {
         return double(fontPrefs->fontSize) / double(prefs->defaultMusicFont->fontSize);
     }
     return 1.0;
 }
 
-static std::optional<EvpuFloat> calcAugmentationDotWidth(const FinalePreferencesPtr& prefs, double dotMag)
+static std::optional<EvpuFloat> calcAugmentationDotWidth(const MssPreferencesPtr& prefs, double dotMag)
 {
     if (!prefs->musicFontName.empty()) {
         if (auto musicFontWidth = utils::smuflGlyphWidthForFont(prefs->musicFontName, "augmentationDot")) {
@@ -367,7 +312,7 @@ static std::optional<EvpuFloat> calcAugmentationDotWidth(const FinalePreferences
         return std::nullopt;
     }
 
-    const auto augDotFontInfo = options::FontOptions::getFontInfo(prefs->document, options::FontOptions::FontType::AugDots);
+    const auto augDotFontInfo = prefs->fontOptions->getFontInfo(options::FontOptions::FontType::AugDots);
     if (!augDotFontInfo) {
         return std::nullopt;
     }
@@ -382,7 +327,7 @@ static std::optional<EvpuFloat> calcAugmentationDotWidth(const FinalePreferences
     return std::nullopt;
 }
 
-static std::optional<EvpuFloat> calcRepeatDotWidth(const FinalePreferencesPtr& prefs)
+static std::optional<EvpuFloat> calcRepeatDotWidth(const MssPreferencesPtr& prefs)
 {
     if (!prefs->musicFontName.empty()) {
         return utils::smuflGlyphWidthForFont(prefs->musicFontName, "repeatDot");
@@ -399,12 +344,12 @@ static void writeFontPref(XmlElement& styleElement, const std::string& namePrefi
     setElementValue(styleElement, namePrefix + "FontStyle", museFontEfx(fontInfo));
 }
 
-static double calcMusicalSymbolScale(const FinalePreferencesPtr& prefs, const FontInfo* fontInfo)
+static double calcMusicalSymbolScale(const MssPreferencesPtr& prefs, const FontInfo* fontInfo)
 {
     double symbolScale = double(fontInfo->fontSize);
     if (fontInfo->calcIsSymbolFont()) {
         symbolScale /= double(prefs->defaultMusicFont->fontSize); /// @todo account for fixed/non-fixed
-    } else if (const auto textBlockFont = options::FontOptions::getFontInfo(prefs->document, options::FontOptions::FontType::TextBlock)) {
+    } else if (const auto textBlockFont = prefs->fontOptions->getFontInfo(options::FontOptions::FontType::TextBlock)) {
         /// Fonts not recognised as symbols likely have their symbols scaled to text size
         symbolScale /= double(textBlockFont->fontSize);
     } else {
@@ -416,9 +361,9 @@ static double calcMusicalSymbolScale(const FinalePreferencesPtr& prefs, const Fo
     return symbolScale;
 }
 
-static void writeDefaultFontPref(XmlElement& styleElement, const FinalePreferencesPtr& prefs, const std::string& namePrefix, options::FontOptions::FontType type)
+static void writeDefaultFontPref(XmlElement& styleElement, const MssPreferencesPtr& prefs, const std::string& namePrefix, options::FontOptions::FontType type)
 {
-    if (auto fontPrefs = options::FontOptions::getFontInfo(prefs->document, type)) {
+    if (auto fontPrefs = prefs->fontOptions->getFontInfo(type)) {
         // If font is a symbols font, write text settings from TextBlock and set symbol scaling.
         if (type != options::FontOptions::FontType::TextBlock && fontIsEngravingWithMappedLegacy(fontPrefs.get())) {
             writeDefaultFontPref(styleElement, prefs, namePrefix, options::FontOptions::FontType::TextBlock);
@@ -466,7 +411,7 @@ static void writeFramePrefs(XmlElement& styleElement, const std::string& namePre
                     enclosure->roundCorners ? int(lround(enclosure->cornerRadius / EFIX_PER_EVPU)) : 0);
 }
 
-static void writeCategoryTextFontPref(XmlElement& styleElement, const FinalePreferencesPtr& prefs, const std::string& namePrefix, others::MarkingCategory::CategoryType categoryType)
+static void writeCategoryTextFontPref(XmlElement& styleElement, const MssPreferencesPtr& prefs, const std::string& namePrefix, others::MarkingCategory::CategoryType categoryType)
 {
     auto cat = prefs->document->getOthers()->get<others::MarkingCategory>(prefs->forPartId, Cmper(categoryType));
     if (!cat) {
@@ -499,7 +444,7 @@ static void writeCategoryTextFontPref(XmlElement& styleElement, const FinalePref
     }
 }
 
-static void writePagePrefs(XmlElement& styleElement, const FinalePreferencesPtr& prefs)
+static void writePagePrefs(XmlElement& styleElement, const MssPreferencesPtr& prefs)
 {
     auto pagePrefs = prefs->pageFormat;
 
@@ -539,9 +484,9 @@ static void writePagePrefs(XmlElement& styleElement, const FinalePreferencesPtr&
     }
 }
 
-static void writeLyricsPrefs(XmlElement& styleElement, const FinalePreferencesPtr& prefs)
+static void writeLyricsPrefs(XmlElement& styleElement, const MssPreferencesPtr& prefs)
 {
-    auto fontInfo = options::FontOptions::getFontInfo(prefs->document, options::FontOptions::FontType::LyricVerse);
+    auto fontInfo = prefs->fontOptions->getFontInfo(options::FontOptions::FontType::LyricVerse);
     for (auto [verseNumber, evenOdd] : {
             std::make_pair(1, "Odd"),
             std::make_pair(2, "Even")
@@ -557,7 +502,7 @@ static void writeLyricsPrefs(XmlElement& styleElement, const FinalePreferencesPt
     }
 }
 
-void writeLineMeasurePrefs(XmlElement& styleElement, const FinalePreferencesPtr& prefs)
+void writeLineMeasurePrefs(XmlElement& styleElement, const MssPreferencesPtr& prefs)
 {
     using RepeatWingStyle = options::RepeatOptions::WingStyle;
 
@@ -639,13 +584,13 @@ void writeLineMeasurePrefs(XmlElement& styleElement, const FinalePreferencesPtr&
     setElementValue(styleElement, "repeatPlayCountShow", false);
 }
 
-void writeStemPrefs(XmlElement& styleElement, const FinalePreferencesPtr& prefs)
+void writeStemPrefs(XmlElement& styleElement, const MssPreferencesPtr& prefs)
 {
     bool useStraightFlags = prefs->flagOptions->straightFlags;
     if (!useStraightFlags && prefs->musicSymbolOptions) {
         // Some documents using certain music fonts (e.g., Pmusic) have straight flags as regular flag characters.
         // Check flagUp and if that is straight, assume the others are straight as well.
-        if (const auto flagFont = options::FontOptions::getFontInfo(prefs->document, options::FontOptions::FontType::Flags)) {
+        if (const auto flagFont = prefs->fontOptions->getFontInfo(options::FontOptions::FontType::Flags)) {
             if (const auto glyphName = utils::smuflGlyphNameForFont(flagFont, prefs->musicSymbolOptions->flagUp)) {
                 if (glyphName.value() == "flag8thUpStraight") {
                     useStraightFlags = true;
@@ -661,7 +606,7 @@ void writeStemPrefs(XmlElement& styleElement, const FinalePreferencesPtr& prefs)
     setElementValue(styleElement, "stemSlashThickness", prefs->graceOptions->graceSlashWidth / EFIX_PER_SPACE);
 }
 
-void writeMusicSpacingPrefs(XmlElement& styleElement, const FinalePreferencesPtr& prefs)
+void writeMusicSpacingPrefs(XmlElement& styleElement, const MssPreferencesPtr& prefs)
 {
     setElementValue(styleElement, "minMeasureWidth", prefs->musicSpacing->minWidth / EVPU_PER_SPACE);
     setElementValue(styleElement, "minNoteDistance", prefs->musicSpacing->minDistance / EVPU_PER_SPACE);
@@ -695,7 +640,7 @@ void writeMusicSpacingPrefs(XmlElement& styleElement, const FinalePreferencesPtr
     setElementValue(styleElement, "articulationKeepTogether", false);
 }
 
-void writeNoteRelatedPrefs(XmlElement& styleElement, const FinalePreferencesPtr& prefs)
+void writeNoteRelatedPrefs(XmlElement& styleElement, const MssPreferencesPtr& prefs)
 {
     setElementValue(styleElement, "accidentalDistance", prefs->accidentalOptions->acciAcciSpace / EVPU_PER_SPACE);
     setElementValue(styleElement, "accidentalNoteDistance", prefs->accidentalOptions->acciNoteSpace / EVPU_PER_SPACE);
@@ -725,7 +670,7 @@ void writeNoteRelatedPrefs(XmlElement& styleElement, const FinalePreferencesPtr&
     setElementValue(styleElement, "tremoloStyle", 1); // MuseScore importer writes TremoloStyle::TRADITIONAL.
 }
 
-void writeSmartShapePrefs(XmlElement& styleElement, const FinalePreferencesPtr& prefs)
+void writeSmartShapePrefs(XmlElement& styleElement, const MssPreferencesPtr& prefs)
 {
     const auto& smartShapePrefs = prefs->smartShapeOptions;
     const auto& tiePrefs = prefs->tieOptions;
@@ -794,7 +739,7 @@ void writeSmartShapePrefs(XmlElement& styleElement, const FinalePreferencesPtr& 
     }
 }
 
-void writeMeasureNumberPrefs(XmlElement& styleElement, const FinalePreferencesPtr& prefs)
+void writeMeasureNumberPrefs(XmlElement& styleElement, const MssPreferencesPtr& prefs)
 {
     setElementValue(styleElement, "showMeasureNumber", bool(prefs->measNumScorePart));
     if (prefs->measNumScorePart) {
@@ -904,7 +849,7 @@ void writeMeasureNumberPrefs(XmlElement& styleElement, const FinalePreferencesPt
     setElementValue(styleElement, "mmRestOldStyleSpacing", prefs->mmRestOptions->symSpacing / EVPU_PER_SPACE);
 }
 
-void writeRepeatEndingPrefs(XmlElement& styleElement, const FinalePreferencesPtr& prefs)
+void writeRepeatEndingPrefs(XmlElement& styleElement, const MssPreferencesPtr& prefs)
 {
     const auto& repeatOptions = prefs->repeatOptions;
     setElementValue(styleElement, "voltaLineWidth", repeatOptions->bracketLineWidth / EFIX_PER_SPACE);
@@ -922,7 +867,7 @@ void writeRepeatEndingPrefs(XmlElement& styleElement, const FinalePreferencesPtr
     // setElementValue(styleElement, "voltaAlignEndLeftOfBarline", false);
 }
 
-void writeTupletPrefs(XmlElement& styleElement, const FinalePreferencesPtr& prefs)
+void writeTupletPrefs(XmlElement& styleElement, const MssPreferencesPtr& prefs)
 {
     using TupletOptions = options::TupletOptions;
     const auto& tupletOptions = prefs->tupletOptions;
@@ -973,7 +918,7 @@ void writeTupletPrefs(XmlElement& styleElement, const FinalePreferencesPtr& pref
         setElementValue(styleElement, "tupletBracketType", 0);        
     }
 
-    const auto& fontInfo = options::FontOptions::getFontInfo(prefs->document, options::FontOptions::FontType::Tuplet);
+    const auto& fontInfo = prefs->fontOptions->getFontInfo(options::FontOptions::FontType::Tuplet);
     if (!fontInfo) {
         prefs->denigmaContext->logMessage(LogMsg() << "Unable to load font pref for tuplets", LogSeverity::Warning);
         return;
@@ -992,7 +937,7 @@ void writeTupletPrefs(XmlElement& styleElement, const FinalePreferencesPtr& pref
                     -(std::max)(tupletOptions->leftHookLen, tupletOptions->rightHookLen) / EVPU_PER_SPACE); /// or use average
 }
 
-void writeMarkingPrefs(XmlElement& styleElement, const FinalePreferencesPtr& prefs)
+void writeMarkingPrefs(XmlElement& styleElement, const MssPreferencesPtr& prefs)
 {
     using FontType = options::FontOptions::FontType;
     using CategoryType = others::MarkingCategory::CategoryType;
@@ -1014,7 +959,7 @@ void writeMarkingPrefs(XmlElement& styleElement, const FinalePreferencesPtr& pre
         }
     }
     // Load font preferences for Text Blocks
-    auto textBlockFont = options::FontOptions::getFontInfo(prefs->document, FontType::TextBlock);
+    auto textBlockFont = prefs->fontOptions->getFontInfo(FontType::TextBlock);
     if (!textBlockFont) {
         throw std::invalid_argument("unable to find font prefs for Text Blocks");
     }
@@ -1096,7 +1041,7 @@ void writeMarkingPrefs(XmlElement& styleElement, const FinalePreferencesPtr& pre
     }
 }
 
-static void processPart(const std::filesystem::path& outputPath, const DocumentPtr& document, const DenigmaContext& denigmaContext, const MusxInstance<others::PartDefinition>& part = nullptr)
+static void processPart(const std::filesystem::path& outputPath, const DocumentPtr& document, const FinaleOptions& finaleOptions, const DenigmaContext& denigmaContext, const MusxInstance<others::PartDefinition>& part = nullptr)
 {
     // calculate actual output path
     std::filesystem::path qualifiedOutputPath = outputPath;
@@ -1112,7 +1057,7 @@ static void processPart(const std::filesystem::path& outputPath, const DocumentP
     if (!denigmaContext.validatePathsAndOptions(qualifiedOutputPath)) return;
 
     const Cmper forPartId = part ? part->getCmper() : 0;
-    auto prefs = getCurrentPrefs(document, forPartId, denigmaContext);
+    auto prefs = getCurrentPrefs(document, finaleOptions, forPartId, denigmaContext);
 
     // extract document to mss
     XmlDocument mssDoc; // output
@@ -1153,8 +1098,9 @@ void convert(const std::filesystem::path& outputPath, const CommandInputData& in
 #endif
 
     auto document = DocumentFactory::create<MusxReader>(inputData.primaryBuffer);
+    auto finaleOptions = loadFinaleOptions(document);
     if (denigmaContext.allPartsAndScore || !denigmaContext.partName.has_value()) {
-        processPart(outputPath, document, denigmaContext); // process the score
+        processPart(outputPath, document, finaleOptions, denigmaContext); // process the score
     }
     bool foundPart = false;
     if (denigmaContext.allPartsAndScore || denigmaContext.partName.has_value()) {
@@ -1162,9 +1108,9 @@ void convert(const std::filesystem::path& outputPath, const CommandInputData& in
         for (const auto& part : parts) {
             if (part->getCmper() != SCORE_PARTID) {
                 if (denigmaContext.allPartsAndScore) {
-                    processPart(outputPath, document, denigmaContext, part);
+                    processPart(outputPath, document, finaleOptions, denigmaContext, part);
                 } else if (denigmaContext.partName->empty() || part->getName().rfind(denigmaContext.partName.value(), 0) == 0) {
-                    processPart(outputPath, document, denigmaContext, part);
+                    processPart(outputPath, document, finaleOptions, denigmaContext, part);
                     foundPart = true;
                     break;
                 }

--- a/src/finale_options.cpp
+++ b/src/finale_options.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026, Robert Patterson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include "finale_options.h"
+
+#include <stdexcept>
+#include <string>
+
+namespace denigma {
+
+namespace {
+
+template <typename T>
+musx::dom::MusxInstance<T> getRequiredOptions(const musx::dom::DocumentPtr& document, const std::string& optionsName)
+{
+    auto retval = document->getOptions()->get<T>();
+    if (!retval) {
+        throw std::invalid_argument("document contains no default " + optionsName + " options");
+    }
+    return retval;
+}
+
+} // namespace
+
+FinaleOptions loadFinaleOptions(const musx::dom::DocumentPtr& document)
+{
+    using namespace musx::dom;
+
+    FinaleOptions retval;
+
+    retval.fontOptions = getRequiredOptions<options::FontOptions>(document, "font");
+    retval.defaultMusicFont = retval.fontOptions->getFontInfo(options::FontOptions::FontType::Music);
+    if (!retval.defaultMusicFont) {
+        throw std::invalid_argument("document contains no information for the default music font.");
+    }
+
+    retval.accidentalOptions = getRequiredOptions<options::AccidentalOptions>(document, "accidental");
+    retval.alternateNotationOptions = getRequiredOptions<options::AlternateNotationOptions>(document, "alternate notation");
+    retval.augDotOptions = getRequiredOptions<options::AugmentationDotOptions>(document, "augmentation dot");
+    retval.barlineOptions = getRequiredOptions<options::BarlineOptions>(document, "barline");
+    retval.beamOptions = getRequiredOptions<options::BeamOptions>(document, "beam");
+    retval.chordOptions = getRequiredOptions<options::ChordOptions>(document, "chord");
+    retval.clefOptions = getRequiredOptions<options::ClefOptions>(document, "clef");
+    retval.flagOptions = getRequiredOptions<options::FlagOptions>(document, "flag");
+    retval.graceOptions = getRequiredOptions<options::GraceNoteOptions>(document, "grace note");
+    retval.keyOptions = getRequiredOptions<options::KeySignatureOptions>(document, "key signature");
+    retval.lineCurveOptions = getRequiredOptions<options::LineCurveOptions>(document, "lines & curves");
+    retval.miscOptions = getRequiredOptions<options::MiscOptions>(document, "miscellaneous");
+    retval.musicSymbolOptions = getRequiredOptions<options::MusicSymbolOptions>(document, "music symbol");
+    retval.mmRestOptions = getRequiredOptions<options::MultimeasureRestOptions>(document, "multimeasure rest");
+    retval.musicSpacing = getRequiredOptions<options::MusicSpacingOptions>(document, "music spacing");
+    retval.pageFormatOptions = getRequiredOptions<options::PageFormatOptions>(document, "page format");
+    retval.braceOptions = getRequiredOptions<options::PianoBraceBracketOptions>(document, "piano braces & brackets");
+    retval.repeatOptions = getRequiredOptions<options::RepeatOptions>(document, "repeat");
+    retval.smartShapeOptions = getRequiredOptions<options::SmartShapeOptions>(document, "smart shape");
+    retval.staffOptions = getRequiredOptions<options::StaffOptions>(document, "staff");
+    retval.stemOptions = getRequiredOptions<options::StemOptions>(document, "stem");
+    retval.tieOptions = getRequiredOptions<options::TieOptions>(document, "tie");
+    retval.timeOptions = getRequiredOptions<options::TimeSignatureOptions>(document, "time signature");
+    retval.tupletOptions = getRequiredOptions<options::TupletOptions>(document, "tuplet");
+
+    return retval;
+}
+
+} // namespace denigma

--- a/src/finale_options.h
+++ b/src/finale_options.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026, Robert Patterson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#pragma once
+
+#include "musx/musx.h"
+
+namespace denigma {
+
+struct FinaleOptions
+{
+    musx::dom::MusxInstance<musx::dom::options::FontOptions> fontOptions;
+    musx::dom::MusxInstance<musx::dom::FontInfo> defaultMusicFont;
+
+    musx::dom::MusxInstance<musx::dom::options::AccidentalOptions> accidentalOptions;
+    musx::dom::MusxInstance<musx::dom::options::AlternateNotationOptions> alternateNotationOptions;
+    musx::dom::MusxInstance<musx::dom::options::AugmentationDotOptions> augDotOptions;
+    musx::dom::MusxInstance<musx::dom::options::BarlineOptions> barlineOptions;
+    musx::dom::MusxInstance<musx::dom::options::BeamOptions> beamOptions;
+    musx::dom::MusxInstance<musx::dom::options::ChordOptions> chordOptions;
+    musx::dom::MusxInstance<musx::dom::options::ClefOptions> clefOptions;
+    musx::dom::MusxInstance<musx::dom::options::FlagOptions> flagOptions;
+    musx::dom::MusxInstance<musx::dom::options::GraceNoteOptions> graceOptions;
+    musx::dom::MusxInstance<musx::dom::options::KeySignatureOptions> keyOptions;
+    musx::dom::MusxInstance<musx::dom::options::LineCurveOptions> lineCurveOptions;
+    musx::dom::MusxInstance<musx::dom::options::MiscOptions> miscOptions;
+    musx::dom::MusxInstance<musx::dom::options::MusicSymbolOptions> musicSymbolOptions;
+    musx::dom::MusxInstance<musx::dom::options::MultimeasureRestOptions> mmRestOptions;
+    musx::dom::MusxInstance<musx::dom::options::MusicSpacingOptions> musicSpacing;
+    musx::dom::MusxInstance<musx::dom::options::PageFormatOptions> pageFormatOptions;
+    musx::dom::MusxInstance<musx::dom::options::PianoBraceBracketOptions> braceOptions;
+    musx::dom::MusxInstance<musx::dom::options::RepeatOptions> repeatOptions;
+    musx::dom::MusxInstance<musx::dom::options::SmartShapeOptions> smartShapeOptions;
+    musx::dom::MusxInstance<musx::dom::options::StaffOptions> staffOptions;
+    musx::dom::MusxInstance<musx::dom::options::StemOptions> stemOptions;
+    musx::dom::MusxInstance<musx::dom::options::TieOptions> tieOptions;
+    musx::dom::MusxInstance<musx::dom::options::TimeSignatureOptions> timeOptions;
+    musx::dom::MusxInstance<musx::dom::options::TupletOptions> tupletOptions;
+};
+
+FinaleOptions loadFinaleOptions(const musx::dom::DocumentPtr& document);
+
+} // namespace denigma


### PR DESCRIPTION
- move `FinaleOptions` to its own TL and make it available to any denigma command.
- refactor `mss` and `mnx` to use it.
