### PR TITLE
Regularize formats namespaces

### DIFF
--- a/src/export/export.cpp
+++ b/src/export/export.cpp
@@ -290,8 +290,8 @@ constexpr auto inputProcessors = []() {
     };
 
     return std::to_array<InputProcessor>({
-            { MUSX_EXTENSION, enigmaxml::extractMusxInputData },
-            { ENIGMAXML_EXTENSION, enigmaxml::readEnigmaXmlInputData },
+            { MUSX_EXTENSION, formats::enigmaxml::detail::extractMusxInputData },
+            { ENIGMAXML_EXTENSION, formats::enigmaxml::detail::readEnigmaXmlInputData },
         });
     }();
 
@@ -304,8 +304,8 @@ constexpr auto outputProcessors = []() {
     };
 
     return std::to_array<OutputProcessor>({
-            { MUSX_EXTENSION, enigmaxml::writeMusxForCli },
-            { ENIGMAXML_EXTENSION, enigmaxml::writeEnigmaXml },
+            { MUSX_EXTENSION, formats::enigmaxml::detail::writeMusxForCli },
+            { ENIGMAXML_EXTENSION, formats::enigmaxml::detail::writeEnigmaXml },
             { MSS_EXTENSION, exportMssWithAdapter },
             { SVG_EXTENSION, exportSvgWithAdapter },
             { MNX_EXTENSION, exportMnxJsonWithAdapter },

--- a/src/formats/enigmaxml/enigmaxml.cpp
+++ b/src/formats/enigmaxml/enigmaxml.cpp
@@ -48,7 +48,11 @@
 constexpr char SCORE_DAT_NAME[] = "score.dat";
 
 namespace denigma {
+namespace formats {
 namespace enigmaxml {
+namespace detail {
+
+CommandInputData extractMusxInputData(const IRandomAccessReader& reader, const DenigmaContext& denigmaContext);
 
 static Buffer gunzipBuffer(const std::string& compressedData)
 {
@@ -406,5 +410,7 @@ void writeMusxForCli(const std::filesystem::path& outputPath, const CommandInput
     }
 }
 
+} // namespace detail
 } // namespace enigmaxml
+} // namespace formats
 } // namespace denigma

--- a/src/formats/enigmaxml/enigmaxml.h
+++ b/src/formats/enigmaxml/enigmaxml.h
@@ -29,7 +29,9 @@
 #include "core/denigma.h"
 
 namespace denigma {
+namespace formats {
 namespace enigmaxml {
+namespace detail {
 
 CommandInputData extractMusxInputData(const std::filesystem::path& inputFile, const DenigmaContext& denigmaContext);
 CommandInputData extractMusxInputData(const IRandomAccessReader& reader, const DenigmaContext& denigmaContext);
@@ -37,5 +39,7 @@ CommandInputData readEnigmaXmlInputData(const std::filesystem::path& inputFile, 
 void writeEnigmaXml(const std::filesystem::path& outputPath, const CommandInputData& inputData, const DenigmaContext& denigmaContext);
 void writeMusxForCli(const std::filesystem::path& outputPath, const CommandInputData& inputData, const DenigmaContext& denigmaContext);
 
+} // namespace detail
 } // namespace enigmaxml
+} // namespace formats
 } // namespace denigma

--- a/src/formats/enigmaxml/enigmaxml_converter.cpp
+++ b/src/formats/enigmaxml/enigmaxml_converter.cpp
@@ -24,7 +24,9 @@
 #include "enigmaxml.h"
 #include "utils/stringutils.h"
 
-namespace denigma::formats::enigmaxml {
+namespace denigma {
+namespace formats {
+namespace enigmaxml {
 
 ConversionResult MusxToEnigmaXmlConverter::convert(const IRandomAccessReader& input,
                                                    std::ostream& output,
@@ -40,7 +42,7 @@ ConversionResult MusxToEnigmaXmlConverter::convert(const IRandomAccessReader& in
     context.conversionResult = &result;
     MusxLoggerScope musxLogger(makeMusxLogCallback(context));
 
-    const Buffer buffer = denigma::enigmaxml::extractMusxInputData(input, context).primaryBuffer;
+    const Buffer buffer = detail::extractMusxInputData(input, context).primaryBuffer;
     output.write(buffer.data(), static_cast<std::streamsize>(buffer.size()));
     return result;
 }
@@ -57,4 +59,6 @@ void registerConverters(ConverterRegistry& registry)
     registry.add(std::make_unique<MusxToEnigmaXmlConverter>());
 }
 
-} // namespace denigma::formats::enigmaxml
+} // namespace enigmaxml
+} // namespace formats
+} // namespace denigma

--- a/src/formats/mnx/mnx.cpp
+++ b/src/formats/mnx/mnx.cpp
@@ -33,7 +33,9 @@ using namespace musx::dom;
 using namespace musx::factory;
 
 namespace denigma {
-namespace mnxexp {
+namespace formats {
+namespace mnx {
+namespace detail {
 
 namespace {
 
@@ -130,7 +132,7 @@ std::optional<int> MnxMusxMapping::mnxPartStaffFromStaff(StaffCmper staff) const
     return static_cast<int>(std::distance(currPartStaves.begin(), it) + 1);
 }
 
-std::string mnxPartDisplayName(const MnxMusxMappingPtr&, const mnx::Part& part)
+std::string mnxPartDisplayName(const MnxMusxMappingPtr&, const mnxdom::Part& part)
 {
     const std::string partId = part.id_or(std::to_string(part.calcArrayIndex()));
     if (part.name() && !part.name().value().empty()) {
@@ -236,7 +238,7 @@ static void createMappings(const MnxMusxMappingPtr& context)
     }
 }
 
-static std::unique_ptr<mnx::Document> createMnxDocument(const CommandInputData& inputData, const DenigmaContext& denigmaContext)
+static std::unique_ptr<mnxdom::Document> createMnxDocument(const CommandInputData& inputData, const DenigmaContext& denigmaContext)
 {
     DocumentFactory::CreateOptions::EmbeddedGraphicFiles embeddedGraphicFiles;
     if (!inputData.embeddedGraphics.empty()) {
@@ -254,7 +256,7 @@ static std::unique_ptr<mnx::Document> createMnxDocument(const CommandInputData& 
         std::move(embeddedGraphicFiles));
     auto document = DocumentFactory::create<MusxReader>(inputData.primaryBuffer, std::move(createOptions));
     auto context = std::make_shared<MnxMusxMapping>(denigmaContext, document);
-    context->mnxDocument = std::make_unique<mnx::Document>();
+    context->mnxDocument = std::make_unique<mnxdom::Document>();
     context->musxParts = others::PartDefinition::getInUserOrder(document);
     MusxLoggerScope mnxMusxLogger(makeMusxLogCallback(context));
 
@@ -278,18 +280,18 @@ static std::unique_ptr<mnx::Document> createMnxDocument(const CommandInputData& 
     return std::move(context->mnxDocument);
 }
 
-static void validateMnxDocument(const mnx::Document& mnxDocument, const DenigmaContext& denigmaContext)
+static void validateMnxDocument(const mnxdom::Document& mnxDocument, const DenigmaContext& denigmaContext)
 {
     if (!denigmaContext.noValidate) {
         denigmaContext.logMessage(LogMsg() << "Validation starting.", MessageSeverity::Verbose);
-        if (auto validateResult = mnx::validation::schemaValidate(mnxDocument, denigmaContext.mnxSchema); !validateResult) {
+        if (auto validateResult = mnxdom::validation::schemaValidate(mnxDocument, denigmaContext.mnxSchema); !validateResult) {
             denigmaContext.logMessage(LogMsg() << "Schema validation errors:", MessageSeverity::Warning);
             for (const auto& error : validateResult.errors) {
                 denigmaContext.logMessage(LogMsg() << "    " << error.to_string(), MessageSeverity::Warning);
             }
         } else {
             denigmaContext.logMessage(LogMsg() << "Schema validation succeeded.");
-            if (auto semanticResult = mnx::validation::semanticValidate(mnxDocument); !semanticResult) {
+            if (auto semanticResult = mnxdom::validation::semanticValidate(mnxDocument); !semanticResult) {
                 denigmaContext.logMessage(LogMsg() << "Semantic validation errors:", MessageSeverity::Warning);
                 for (const auto& error : semanticResult.errors) {
                     denigmaContext.logMessage(LogMsg() << "    " << error.to_string(4), MessageSeverity::Warning);
@@ -303,7 +305,7 @@ static void validateMnxDocument(const mnx::Document& mnxDocument, const DenigmaC
     }
 }
 
-static void writeMnxDocumentJson(std::ostream& output, const mnx::Document& mnxDocument, const DenigmaContext& denigmaContext)
+static void writeMnxDocumentJson(std::ostream& output, const mnxdom::Document& mnxDocument, const DenigmaContext& denigmaContext)
 {
     output << mnxDocument.root()->dump(denigmaContext.indentSpaces.value_or(-1));
 }
@@ -338,5 +340,7 @@ void exportMnx(const std::filesystem::path& outputPath, const CommandInputData& 
     exportJson(outputPath, inputData, denigmaContext);
 }
 
-} // namespace mnxexp
+} // namespace detail
+} // namespace mnx
+} // namespace formats
 } // namespace denigma

--- a/src/formats/mnx/mnx.h
+++ b/src/formats/mnx/mnx.h
@@ -44,7 +44,9 @@ using namespace musx::dom;
 using namespace musx::util;
 
 namespace denigma {
-namespace mnxexp {
+namespace formats {
+namespace mnx {
+namespace detail {
 
 enum class EntryTargetKind
 {
@@ -55,7 +57,7 @@ enum class EntryTargetKind
 struct EntryTarget
 {
     EntryTargetKind kind;
-    mnx::json_pointer pointer;
+    mnxdom::json_pointer pointer;
 };
 
 // stoopid c++17 standard does not include a hash for tuple
@@ -80,7 +82,7 @@ struct MnxMusxMapping
     const DenigmaContext* denigmaContext;
     musx::dom::DocumentPtr document;
     FinaleOptions finaleOptions;
-    std::unique_ptr<mnx::Document> mnxDocument;
+    std::unique_ptr<mnxdom::Document> mnxDocument;
     MusxInstanceList<others::PartDefinition> musxParts;
 
     std::unordered_map<std::string, std::vector<StaffCmper>> part2Inst;
@@ -90,13 +92,13 @@ struct MnxMusxMapping
 
     // musx mappings
     std::unordered_map<Cmper, classify::Jump> textRepeat2Jump;
-    std::unordered_map<std::string, mnx::json_pointer> noteJsonById;
+    std::unordered_map<std::string, mnxdom::json_pointer> noteJsonById;
     std::unordered_map<EntryNumber, EntryTarget> entryTargetByNumber;
 
     struct DeferredJumpTie {
         std::string startNoteId;
         std::string endNoteId;
-        std::optional<mnx::SlurTieSide> side;
+        std::optional<mnxdom::SlurTieSide> side;
     };
 
     std::vector<DeferredJumpTie> deferredJumpTies;
@@ -158,7 +160,7 @@ struct MnxMusxMapping
 };
 
 std::string mnxPartDisplayName(const MnxMusxMappingPtr& context, const std::string& partId);
-std::string mnxPartDisplayName(const MnxMusxMappingPtr& context, const mnx::Part& part);
+std::string mnxPartDisplayName(const MnxMusxMappingPtr& context, const mnxdom::Part& part);
 std::string mnxPartDisplayList(const MnxMusxMappingPtr& context, const std::vector<std::string>& partIds);
 
 inline std::string calcSystemLayoutId(Cmper partId, Cmper systemId)
@@ -225,7 +227,7 @@ void createLayouts(const MnxMusxMappingPtr& context);
 void createGlobal(const MnxMusxMappingPtr& context);
 void createParts(const MnxMusxMappingPtr& context);
 void createSequences(const MnxMusxMappingPtr& context,
-    mnx::part::Measure& mnxMeasure,
+    mnxdom::part::Measure& mnxMeasure,
     std::optional<int> mnxStaffNumber,
     const MusxInstance<others::Measure>& musxMeasure);
 void finalizeJumpTies(const MnxMusxMappingPtr& context);
@@ -237,5 +239,7 @@ void exportMnx(const std::filesystem::path& outputPath, const CommandInputData& 
 template <typename ToEnum, typename FromEnum>
 ToEnum enumConvert(FromEnum value);
 
-} // namespace mnxexp
+} // namespace detail
+} // namespace mnx
+} // namespace formats
 } // namespace denigma

--- a/src/formats/mnx/mnx_converter.cpp
+++ b/src/formats/mnx/mnx_converter.cpp
@@ -30,7 +30,9 @@
 #include "mnx.h"
 #include "utils/stringutils.h"
 
-namespace denigma::formats::mnx {
+namespace denigma {
+namespace formats {
+namespace mnx {
 
 namespace {
 
@@ -70,7 +72,7 @@ ConversionResult EnigmaXmlToMnxJsonConverter::convert(std::span<const std::byte>
     MusxLoggerScope musxLogger(makeMusxLogCallback(context));
 
     try {
-        mnxexp::exportJson(output, CommandInputData{ std::move(buffer), std::nullopt, {} }, context);
+        detail::exportJson(output, CommandInputData{ std::move(buffer), std::nullopt, {} }, context);
     } catch (const std::exception& ex) {
         context.logMessage(LogMsg() << "unable to convert Enigma XML to MNX JSON", MessageSeverity::Error);
         context.logMessage(LogMsg() << " (exception: " << ex.what() << ")", MessageSeverity::Error);
@@ -96,7 +98,7 @@ ConversionResult MusxToMnxJsonConverter::convert(const IRandomAccessReader& inpu
     MusxLoggerScope musxLogger(makeMusxLogCallback(context));
 
     try {
-        mnxexp::exportJson(output, enigmaxml::extractMusxInputData(input, context), context);
+        detail::exportJson(output, formats::enigmaxml::detail::extractMusxInputData(input, context), context);
     } catch (const std::exception& ex) {
         context.logMessage(LogMsg() << "unable to convert MUSX to MNX JSON", MessageSeverity::Error);
         context.logMessage(LogMsg() << " (exception: " << ex.what() << ")", MessageSeverity::Error);
@@ -117,4 +119,6 @@ void registerConverters(ConverterRegistry& registry)
     registry.add(std::make_unique<MusxToMnxJsonConverter>());
 }
 
-} // namespace denigma::formats::mnx
+} // namespace mnx
+} // namespace formats
+} // namespace denigma

--- a/src/formats/mnx/mnx_enums.cpp
+++ b/src/formats/mnx/mnx_enums.cpp
@@ -38,7 +38,9 @@ ToEnum enumConvert(FromEnum value) { \
 }
 
 namespace denigma {
-namespace mnxexp {
+namespace formats {
+namespace mnx {
+namespace detail {
 
 // Primary template definition (if needed)
 template <typename ToEnum, typename FromEnum>
@@ -48,80 +50,82 @@ ToEnum enumConvert(FromEnum) {
 }
 
 using BarlineType = musx::dom::others::Measure::BarlineType;
-BEGIN_ENUM_CONVERSION(BarlineType, mnx::BarlineType)
-    case BarlineType::None: return mnx::BarlineType::NoBarline;
-    case BarlineType::Normal: return mnx::BarlineType::Regular;
-    case BarlineType::Double: return mnx::BarlineType::Double;
-    case BarlineType::Final: return mnx::BarlineType::Final;
-    case BarlineType::Solid: return mnx::BarlineType::Heavy;
-    case BarlineType::Dashed: return mnx::BarlineType::Dashed;
-    case BarlineType::Tick: return mnx::BarlineType::Tick;
+BEGIN_ENUM_CONVERSION(BarlineType, mnxdom::BarlineType)
+    case BarlineType::None: return mnxdom::BarlineType::NoBarline;
+    case BarlineType::Normal: return mnxdom::BarlineType::Regular;
+    case BarlineType::Double: return mnxdom::BarlineType::Double;
+    case BarlineType::Final: return mnxdom::BarlineType::Final;
+    case BarlineType::Solid: return mnxdom::BarlineType::Heavy;
+    case BarlineType::Dashed: return mnxdom::BarlineType::Dashed;
+    case BarlineType::Tick: return mnxdom::BarlineType::Tick;
 END_ENUM_CONVERSION
 
-BEGIN_ENUM_CONVERSION(musx::dom::NoteType, mnx::NoteValueBase)
-    case NoteType::Note2048th: return mnx::NoteValueBase::Note2048th;
-    case NoteType::Note1024th: return mnx::NoteValueBase::Note1024th;
-    case NoteType::Note512th: return mnx::NoteValueBase::Note512th;
-    case NoteType::Note128th: return mnx::NoteValueBase::Note128th;
-    case NoteType::Note64th: return mnx::NoteValueBase::Note64th;
-    case NoteType::Note32nd: return mnx::NoteValueBase::Note32nd;
-    case NoteType::Note16th: return mnx::NoteValueBase::Note16th;
-    case NoteType::Eighth: return mnx::NoteValueBase::Eighth;
-    case NoteType::Quarter: return mnx::NoteValueBase::Quarter;
-    case NoteType::Half: return mnx::NoteValueBase::Half;
-    case NoteType::Whole: return mnx::NoteValueBase::Whole;
-    case NoteType::Breve: return mnx::NoteValueBase::Breve;
-    case NoteType::Longa: return mnx::NoteValueBase::Longa;
-    case NoteType::Maxima: return mnx::NoteValueBase::Maxima;
+BEGIN_ENUM_CONVERSION(musx::dom::NoteType, mnxdom::NoteValueBase)
+    case NoteType::Note2048th: return mnxdom::NoteValueBase::Note2048th;
+    case NoteType::Note1024th: return mnxdom::NoteValueBase::Note1024th;
+    case NoteType::Note512th: return mnxdom::NoteValueBase::Note512th;
+    case NoteType::Note128th: return mnxdom::NoteValueBase::Note128th;
+    case NoteType::Note64th: return mnxdom::NoteValueBase::Note64th;
+    case NoteType::Note32nd: return mnxdom::NoteValueBase::Note32nd;
+    case NoteType::Note16th: return mnxdom::NoteValueBase::Note16th;
+    case NoteType::Eighth: return mnxdom::NoteValueBase::Eighth;
+    case NoteType::Quarter: return mnxdom::NoteValueBase::Quarter;
+    case NoteType::Half: return mnxdom::NoteValueBase::Half;
+    case NoteType::Whole: return mnxdom::NoteValueBase::Whole;
+    case NoteType::Breve: return mnxdom::NoteValueBase::Breve;
+    case NoteType::Longa: return mnxdom::NoteValueBase::Longa;
+    case NoteType::Maxima: return mnxdom::NoteValueBase::Maxima;
 END_ENUM_CONVERSION
 
-BEGIN_ENUM_CONVERSION(musx::dom::NoteType, mnx::TimeSignatureUnit)
-    case NoteType::Note128th: return mnx::TimeSignatureUnit::Value128th;
-    case NoteType::Note64th: return mnx::TimeSignatureUnit::Value64th;
-    case NoteType::Note32nd: return mnx::TimeSignatureUnit::Value32nd;
-    case NoteType::Note16th: return mnx::TimeSignatureUnit::Value16th;
-    case NoteType::Eighth: return mnx::TimeSignatureUnit::Eighth;
-    case NoteType::Quarter: return mnx::TimeSignatureUnit::Quarter;
-    case NoteType::Half: return mnx::TimeSignatureUnit::Half;
-    case NoteType::Whole: return mnx::TimeSignatureUnit::Whole;
+BEGIN_ENUM_CONVERSION(musx::dom::NoteType, mnxdom::TimeSignatureUnit)
+    case NoteType::Note128th: return mnxdom::TimeSignatureUnit::Value128th;
+    case NoteType::Note64th: return mnxdom::TimeSignatureUnit::Value64th;
+    case NoteType::Note32nd: return mnxdom::TimeSignatureUnit::Value32nd;
+    case NoteType::Note16th: return mnxdom::TimeSignatureUnit::Value16th;
+    case NoteType::Eighth: return mnxdom::TimeSignatureUnit::Eighth;
+    case NoteType::Quarter: return mnxdom::TimeSignatureUnit::Quarter;
+    case NoteType::Half: return mnxdom::TimeSignatureUnit::Half;
+    case NoteType::Whole: return mnxdom::TimeSignatureUnit::Whole;
 END_ENUM_CONVERSION
 
-BEGIN_ENUM_CONVERSION(details::TupletDef::AutoBracketStyle, mnx::AutoYesNo)
-    case details::TupletDef::AutoBracketStyle::Always: return mnx::AutoYesNo::Yes;
-    case details::TupletDef::AutoBracketStyle::NeverBeamSide: return mnx::AutoYesNo::Yes; // currently there is no exact analog for this Finale option in Mnx.
-    case details::TupletDef::AutoBracketStyle::UnbeamedOnly: return mnx::AutoYesNo::Auto;
+BEGIN_ENUM_CONVERSION(details::TupletDef::AutoBracketStyle, mnxdom::AutoYesNo)
+    case details::TupletDef::AutoBracketStyle::Always: return mnxdom::AutoYesNo::Yes;
+    case details::TupletDef::AutoBracketStyle::NeverBeamSide: return mnxdom::AutoYesNo::Yes; // currently there is no exact analog for this Finale option in Mnx.
+    case details::TupletDef::AutoBracketStyle::UnbeamedOnly: return mnxdom::AutoYesNo::Auto;
 END_ENUM_CONVERSION
 
-BEGIN_ENUM_CONVERSION(music_theory::NoteName, mnx::NoteStep)
-    case music_theory::NoteName::C: return mnx::NoteStep::C;
-    case music_theory::NoteName::D: return mnx::NoteStep::D;
-    case music_theory::NoteName::E: return mnx::NoteStep::E;
-    case music_theory::NoteName::F: return mnx::NoteStep::F;
-    case music_theory::NoteName::G: return mnx::NoteStep::G;
-    case music_theory::NoteName::A: return mnx::NoteStep::A;
-    case music_theory::NoteName::B: return mnx::NoteStep::B;
+BEGIN_ENUM_CONVERSION(music_theory::NoteName, mnxdom::NoteStep)
+    case music_theory::NoteName::C: return mnxdom::NoteStep::C;
+    case music_theory::NoteName::D: return mnxdom::NoteStep::D;
+    case music_theory::NoteName::E: return mnxdom::NoteStep::E;
+    case music_theory::NoteName::F: return mnxdom::NoteStep::F;
+    case music_theory::NoteName::G: return mnxdom::NoteStep::G;
+    case music_theory::NoteName::A: return mnxdom::NoteStep::A;
+    case music_theory::NoteName::B: return mnxdom::NoteStep::B;
 END_ENUM_CONVERSION
 
-BEGIN_ENUM_CONVERSION(VerticalPlacement, mnx::Orientation)
-    case VerticalPlacement::NotApplicable: return mnx::Orientation::Auto;
-    case VerticalPlacement::Float: return mnx::Orientation::Auto;
-    case VerticalPlacement::Above: return mnx::Orientation::Above;
-    case VerticalPlacement::Below: return mnx::Orientation::Below;
+BEGIN_ENUM_CONVERSION(VerticalPlacement, mnxdom::Orientation)
+    case VerticalPlacement::NotApplicable: return mnxdom::Orientation::Auto;
+    case VerticalPlacement::Float: return mnxdom::Orientation::Auto;
+    case VerticalPlacement::Above: return mnxdom::Orientation::Above;
+    case VerticalPlacement::Below: return mnxdom::Orientation::Below;
 END_ENUM_CONVERSION
 
-BEGIN_ENUM_CONVERSION(VerticalPlacement, mnx::MultiStaffOrientation)
-    case VerticalPlacement::NotApplicable: return mnx::MultiStaffOrientation::Auto;
-    case VerticalPlacement::Float: return mnx::MultiStaffOrientation::Auto;
-    case VerticalPlacement::Above: return mnx::MultiStaffOrientation::Above;
-    case VerticalPlacement::Below: return mnx::MultiStaffOrientation::Below;
+BEGIN_ENUM_CONVERSION(VerticalPlacement, mnxdom::MultiStaffOrientation)
+    case VerticalPlacement::NotApplicable: return mnxdom::MultiStaffOrientation::Auto;
+    case VerticalPlacement::Float: return mnxdom::MultiStaffOrientation::Auto;
+    case VerticalPlacement::Above: return mnxdom::MultiStaffOrientation::Above;
+    case VerticalPlacement::Below: return mnxdom::MultiStaffOrientation::Below;
 END_ENUM_CONVERSION
 
-BEGIN_ENUM_CONVERSION(others::SmartShape::ShapeType, mnx::OttavaAmount)
-    case others::SmartShape::ShapeType::OctaveDown: return mnx::OttavaAmount::OctaveDown;
-    case others::SmartShape::ShapeType::OctaveUp: return mnx::OttavaAmount::OctaveUp;
-    case others::SmartShape::ShapeType::TwoOctaveDown: return mnx::OttavaAmount::TwoOctavesDown;
-    case others::SmartShape::ShapeType::TwoOctaveUp: return mnx::OttavaAmount::TwoOctavesUp;
+BEGIN_ENUM_CONVERSION(others::SmartShape::ShapeType, mnxdom::OttavaAmount)
+    case others::SmartShape::ShapeType::OctaveDown: return mnxdom::OttavaAmount::OctaveDown;
+    case others::SmartShape::ShapeType::OctaveUp: return mnxdom::OttavaAmount::OctaveUp;
+    case others::SmartShape::ShapeType::TwoOctaveDown: return mnxdom::OttavaAmount::TwoOctavesDown;
+    case others::SmartShape::ShapeType::TwoOctaveUp: return mnxdom::OttavaAmount::TwoOctavesUp;
 END_ENUM_CONVERSION
 
-} // namespace mnxexp
+} // namespace detail
+} // namespace mnx
+} // namespace formats
 } // namespace denigma

--- a/src/formats/mnx/mnx_expressions.cpp
+++ b/src/formats/mnx/mnx_expressions.cpp
@@ -25,7 +25,9 @@
 #include "denigma/classify/expressions.h"
 
 namespace denigma {
-namespace mnxexp {
+namespace formats {
+namespace mnx {
+namespace detail {
 
 namespace {
 struct ExpressionAttachmentContext {
@@ -48,11 +50,11 @@ ExpressionAttachmentContext calcAttachmentContext(const MnxMusxMappingPtr& conte
     return result;
 }
 
-std::pair<std::optional<mnx::DynamicValue>, std::optional<mnx::DynamicValue>> calcDynamicType(
+std::pair<std::optional<mnxdom::DynamicValue>, std::optional<mnxdom::DynamicValue>> calcDynamicType(
     classify::Dynamic dynamic, bool& copyGlyphs, bool& isAccent)
 {
-    std::optional<mnx::DynamicValue> dynValue;
-    std::optional<mnx::DynamicValue> attackValue;
+    std::optional<mnxdom::DynamicValue> dynValue;
+    std::optional<mnxdom::DynamicValue> attackValue;
     copyGlyphs = false;
     isAccent = false;
 
@@ -61,81 +63,81 @@ std::pair<std::optional<mnx::DynamicValue>, std::optional<mnx::DynamicValue>> ca
         case DynType::pppppp:
         case DynType::ppppp:
         case DynType::pppp:
-            dynValue = mnx::DynamicValue::ppp;
+            dynValue = mnxdom::DynamicValue::ppp;
             copyGlyphs = true;
             break;
         case DynType::ppp:
-            dynValue = mnx::DynamicValue::ppp;
+            dynValue = mnxdom::DynamicValue::ppp;
             break;
         case DynType::pp:
-            dynValue = mnx::DynamicValue::pp;
+            dynValue = mnxdom::DynamicValue::pp;
             break;
         case DynType::p:
-            dynValue = mnx::DynamicValue::p;
+            dynValue = mnxdom::DynamicValue::p;
             break;
         case DynType::mp:
-            dynValue = mnx::DynamicValue::mp;
+            dynValue = mnxdom::DynamicValue::mp;
             break;
         case DynType::mf:
-            dynValue = mnx::DynamicValue::mf;
+            dynValue = mnxdom::DynamicValue::mf;
             break;
         case DynType::f:
-            dynValue = mnx::DynamicValue::f;
+            dynValue = mnxdom::DynamicValue::f;
             break;
         case DynType::ff:
-            dynValue = mnx::DynamicValue::ff;
+            dynValue = mnxdom::DynamicValue::ff;
             break;
         case DynType::fff:
-            dynValue = mnx::DynamicValue::fff;
+            dynValue = mnxdom::DynamicValue::fff;
             break;
         case DynType::ffff:
         case DynType::fffff:
         case DynType::ffffff:
-            dynValue = mnx::DynamicValue::fff;
+            dynValue = mnxdom::DynamicValue::fff;
             copyGlyphs = true;
             break;
         case DynType::fp:
-            attackValue = mnx::DynamicValue::f;
-            dynValue = mnx::DynamicValue::p;
+            attackValue = mnxdom::DynamicValue::f;
+            dynValue = mnxdom::DynamicValue::p;
             break;
         case DynType::ffp:
-            attackValue = mnx::DynamicValue::ff;
-            dynValue = mnx::DynamicValue::p;
+            attackValue = mnxdom::DynamicValue::ff;
+            dynValue = mnxdom::DynamicValue::p;
             break;
         case DynType::fz:
         case DynType::sf:
         case DynType::sfz:
         case DynType::rf:
         case DynType::rfz:
-            dynValue = mnx::DynamicValue::f;
+            dynValue = mnxdom::DynamicValue::f;
             isAccent = true;
             copyGlyphs = true;
             break;
         case DynType::ffz:
         case DynType::sffz:
-            dynValue = mnx::DynamicValue::ff;
+            dynValue = mnxdom::DynamicValue::ff;
             isAccent = true;
             copyGlyphs = true;
             break;
         case DynType::pf:
-            attackValue = mnx::DynamicValue::p;
-            dynValue = mnx::DynamicValue::f;
+            attackValue = mnxdom::DynamicValue::p;
+            dynValue = mnxdom::DynamicValue::f;
             break;
         case DynType::sfp:
         case DynType::sfzp:
-            attackValue = mnx::DynamicValue::f;
-            dynValue = mnx::DynamicValue::p;
+            attackValue = mnxdom::DynamicValue::f;
+            dynValue = mnxdom::DynamicValue::p;
             isAccent = true;
             copyGlyphs = true;
             break;
         case DynType::sfpp:
-            attackValue = mnx::DynamicValue::f;
-            dynValue = mnx::DynamicValue::pp;
+            attackValue = mnxdom::DynamicValue::f;
+            dynValue = mnxdom::DynamicValue::pp;
             isAccent = true;
             copyGlyphs = true;
             break;
         case DynType::n:
-            dynValue = mnx::DynamicValue::n;
+            dynValue = mnxdom::DynamicValue::n;
             break;
         case DynType::Other:
         case DynType::None:
@@ -145,7 +147,7 @@ std::pair<std::optional<mnx::DynamicValue>, std::optional<mnx::DynamicValue>> ca
     return std::make_pair(dynValue, attackValue);
 }
 
-void appendDynamic(const MnxMusxMappingPtr& context, mnx::part::Measure& mnxMeasure, std::optional<int> mnxStaffNumber,
+void appendDynamic(const MnxMusxMappingPtr& context, mnxdom::part::Measure& mnxMeasure, std::optional<int> mnxStaffNumber,
     const MusxInstance<others::MeasureExprAssign>& asgn, classify::DynamicClassification dynamicClass, VerticalPlacement placement)
 {
     if (asgn->layer > 0 && context->current.cueDiscardPlan.discardLayers.contains(asgn->layer - 1)) {
@@ -164,12 +166,12 @@ void appendDynamic(const MnxMusxMappingPtr& context, mnx::part::Measure& mnxMeas
         glyphs = classify::dynamicCanonicalLetterGlyphs(dynamicClass.dynamic);
     }
 
-    auto mnxDynamic = [&]() -> mnx::part::DynamicGroupBase {
+    auto mnxDynamic = [&]() -> mnxdom::part::DynamicGroupBase {
         using DynRelType = classify::DynamicChange;
         if (dynamicClass.change != DynRelType::Absolute) {
             auto relValue = dynamicClass.change == DynRelType::RelativeIncrease
-                ? mnx::DynamicRelativeValue::Louder
-                : mnx::DynamicRelativeValue::Softer;
+                ? mnxdom::DynamicRelativeValue::Louder
+                : mnxdom::DynamicRelativeValue::Softer;
             auto dyn = mnxMeasure.ensure_dynamics().appendRelative(relValue, mnxFractionFromEdu(asgn->eduPosition));
             if (dynValue) {
                 dyn.set_value(dynValue.value());
@@ -224,9 +226,9 @@ void appendDynamic(const MnxMusxMappingPtr& context, mnx::part::Measure& mnxMeas
     }
 }
 
-void attachFermata(const MnxMusxMappingPtr& context, mnx::part::Measure& mnxMeasure,
+void attachFermata(const MnxMusxMappingPtr& context, mnxdom::part::Measure& mnxMeasure,
     const MusxInstance<others::MeasureExprAssign>& asgn, const denigma::classify::ExpressionFermata& fermataInfo,
-    const ExpressionAttachmentContext& attachment, const mnx::Fermata& fermata)
+    const ExpressionAttachmentContext& attachment, const mnxdom::Fermata& fermata)
 {
     if (asgn->calcIsPartOfStaffListAssignment() || fermataInfo.isRightBarline) {
         return;
@@ -234,10 +236,10 @@ void attachFermata(const MnxMusxMappingPtr& context, mnx::part::Measure& mnxMeas
     if (attachment.entryTarget) {
         switch (attachment.entryTarget->kind) {
         case EntryTargetKind::Event:
-            mnx::sequence::Event(context->mnxDocument->root(), attachment.entryTarget->pointer).set_fermata(fermata);
+            mnxdom::sequence::Event(context->mnxDocument->root(), attachment.entryTarget->pointer).set_fermata(fermata);
             break;
         case EntryTargetKind::FullMeasureRest:
-            mnx::sequence::FullMeasureRest(context->mnxDocument->root(), attachment.entryTarget->pointer).set_fermata(fermata);
+            mnxdom::sequence::FullMeasureRest(context->mnxDocument->root(), attachment.entryTarget->pointer).set_fermata(fermata);
             break;
         }
     } else if (attachment.entryInfo) {
@@ -256,15 +258,15 @@ void attachFermata(const MnxMusxMappingPtr& context, mnx::part::Measure& mnxMeas
     }
 }
 
-void attachBreathMark(const MnxMusxMappingPtr& context, const ExpressionAttachmentContext& attachment, const mnx::sequence::BreathMark& breathMark) {
+void attachBreathMark(const MnxMusxMappingPtr& context, const ExpressionAttachmentContext& attachment, const mnxdom::sequence::BreathMark& breathMark) {
     if (attachment.entryTarget && attachment.entryTarget->kind == EntryTargetKind::Event) {
-        mnx::sequence::Event(context->mnxDocument->root(), attachment.entryTarget->pointer).ensure_markings().set_breath(breathMark);
+        mnxdom::sequence::Event(context->mnxDocument->root(), attachment.entryTarget->pointer).ensure_markings().set_breath(breathMark);
     }
 };
 } // namespace
 
 void processExpressions(const MnxMusxMappingPtr& context, const MusxInstance<others::Measure>& musxMeasure,
-    mnx::part::Measure& mnxMeasure, std::optional<int> mnxStaffNumber)
+    mnxdom::part::Measure& mnxMeasure, std::optional<int> mnxStaffNumber)
 {
     if (musxMeasure->hasExpression) {
         auto exprAssigns = context->document->getOthers()->getArray<others::MeasureExprAssign>(musxMeasure->getRequestedPartId(), musxMeasure->getCmper());
@@ -306,5 +308,7 @@ void processExpressions(const MnxMusxMappingPtr& context, const MusxInstance<oth
     }
 }
 
-} // namespace mnxexp
+} // namespace detail
+} // namespace mnx
+} // namespace formats
 } // namespace denigma

--- a/src/formats/mnx/mnx_expressions.h
+++ b/src/formats/mnx/mnx_expressions.h
@@ -31,10 +31,14 @@ using namespace musx::dom;
 using namespace musx::util;
 
 namespace denigma {
-namespace mnxexp {
+namespace formats {
+namespace mnx {
+namespace detail {
 
 void processExpressions(const MnxMusxMappingPtr& context, const MusxInstance<others::Measure>& musxMeasure,
-    mnx::part::Measure& mnxMeasure, std::optional<int> mnxStaffNumber);
+    mnxdom::part::Measure& mnxMeasure, std::optional<int> mnxStaffNumber);
 
-} // namespace mnxexp
+} // namespace detail
+} // namespace mnx
+} // namespace formats
 } // namespace denigma

--- a/src/formats/mnx/mnx_formatted_text.cpp
+++ b/src/formats/mnx/mnx_formatted_text.cpp
@@ -32,7 +32,9 @@ using namespace musx::dom;
 using namespace musx::util;
 
 namespace denigma {
-namespace mnxexp {
+namespace formats {
+namespace mnx {
+namespace detail {
 
 namespace {
 
@@ -129,11 +131,11 @@ static void applyStyle(T item, const EnigmaStyles& styles, const MnxFormattedTex
     if (styles.font->fontSize > 0) {
         style.set_size(static_cast<double>(styles.font->fontSize));
     }
-    style.set_or_clear_fontStyle(styles.font->italic ? mnx::FontStyle::Italic : mnx::FontStyle::Plain);
-    style.set_or_clear_weight(styles.font->bold ? mnx::FontWeight::Bold : mnx::FontWeight::Plain);
+    style.set_or_clear_fontStyle(styles.font->italic ? mnxdom::FontStyle::Italic : mnxdom::FontStyle::Plain);
+    style.set_or_clear_weight(styles.font->bold ? mnxdom::FontWeight::Bold : mnxdom::FontWeight::Plain);
 }
 
-static void appendTextChunk(mnx::FormattedText dst, const std::string& text, const EnigmaStyles& styles, const MnxFormattedTextOptions& options, bool addStyle = true)
+static void appendTextChunk(mnxdom::FormattedText dst, const std::string& text, const EnigmaStyles& styles, const MnxFormattedTextOptions& options, bool addStyle = true)
 {
     if (text.empty()) {
         return;
@@ -147,7 +149,7 @@ static void appendTextChunk(mnx::FormattedText dst, const std::string& text, con
     }
 }
 
-static void appendSmuflChunk(mnx::FormattedText dst, const std::string& text, const std::vector<std::string>& glyphs, const EnigmaStyles& styles, const MnxFormattedTextOptions& options, bool addStyle = true)
+static void appendSmuflChunk(mnxdom::FormattedText dst, const std::string& text, const std::vector<std::string>& glyphs, const EnigmaStyles& styles, const MnxFormattedTextOptions& options, bool addStyle = true)
 {
     if (glyphs.empty()) {
         return;
@@ -161,7 +163,7 @@ static void appendSmuflChunk(mnx::FormattedText dst, const std::string& text, co
     }
 }
 
-static void appendConvertedChunk(mnx::FormattedText dst, const std::string& text, const EnigmaStyles& styles, const MnxFormattedTextOptions& options)
+static void appendConvertedChunk(mnxdom::FormattedText dst, const std::string& text, const EnigmaStyles& styles, const MnxFormattedTextOptions& options)
 {
     if (text.empty() || !styles.font || (options.skipHiddenText && styles.font->hidden)) {
         return;
@@ -197,7 +199,7 @@ static void appendConvertedChunk(mnx::FormattedText dst, const std::string& text
 } // namespace
 
 void setFormattedText(
-    mnx::FormattedText dst,
+    mnxdom::FormattedText dst,
     const EnigmaParsingContext& src,
     const MnxFormattedTextOptions& options)
 {
@@ -217,14 +219,16 @@ void setFormattedText(
     }, parsingOptions);
 }
 
-mnx::FormattedText makeFormattedText(
+mnxdom::FormattedText makeFormattedText(
     const EnigmaParsingContext& src,
     const MnxFormattedTextOptions& options)
 {
-    mnx::FormattedText result;
+    mnxdom::FormattedText result;
     setFormattedText(result, src, options);
     return result;
 }
 
-} // namespace mnxexp
+} // namespace detail
+} // namespace mnx
+} // namespace formats
 } // namespace denigma

--- a/src/formats/mnx/mnx_formatted_text.h
+++ b/src/formats/mnx/mnx_formatted_text.h
@@ -31,8 +31,12 @@
 
 #include "musx/musx.h"
 
+#include "mnx_fwd.h"
+
 namespace denigma {
-namespace mnxexp {
+namespace formats {
+namespace mnx {
+namespace detail {
 
 enum class MnxFormattedTextSymbolPolicy
 {
@@ -53,13 +57,15 @@ struct MnxFormattedTextOptions
 };
 
 void setFormattedText(
-    mnx::FormattedText dst,
+    mnxdom::FormattedText dst,
     const musx::util::EnigmaParsingContext& src,
     const MnxFormattedTextOptions& options = {});
 
-mnx::FormattedText makeFormattedText(
+mnxdom::FormattedText makeFormattedText(
     const musx::util::EnigmaParsingContext& src,
     const MnxFormattedTextOptions& options = {});
 
-} // namespace mnxexp
+} // namespace detail
+} // namespace mnx
+} // namespace formats
 } // namespace denigma

--- a/src/formats/mnx/mnx_fwd.h
+++ b/src/formats/mnx/mnx_fwd.h
@@ -25,7 +25,17 @@
 
  // Keep this header dependency free
 
-namespace denigma::mnxexp {
+namespace mnx {
+}
+namespace mnxdom = ::mnx;
+
+namespace denigma {
+namespace formats {
+namespace mnx {
+namespace detail {
 struct MnxMusxMapping;
 using MnxMusxMappingPtr = std::shared_ptr<MnxMusxMapping>;
-}
+} // namespace detail
+} // namespace mnx
+} // namespace formats
+} // namespace denigma

--- a/src/formats/mnx/mnx_global.cpp
+++ b/src/formats/mnx/mnx_global.cpp
@@ -29,10 +29,12 @@
 #include "utils/smufl_support.h"
 
 namespace denigma {
-namespace mnxexp {
+namespace formats {
+namespace mnx {
+namespace detail {
 
 static void assignBarline(
-    mnx::global::Measure& mnxMeasure,
+    mnxdom::global::Measure& mnxMeasure,
     const MusxInstance<others::Measure>& musxMeasure,
     const MusxInstance<options::BarlineOptions>& musxBarlineOptions,
     bool isForFinalMeasure)
@@ -46,26 +48,26 @@ static void assignBarline(
             case others::Measure::BarlineType::Normal:
                 if (isForFinalMeasure && !musxBarlineOptions->drawFinalBarlineOnLastMeas) {
                     // force normal on final bar
-                    mnxMeasure.ensure_barline(mnx::BarlineType::Regular);
+                    mnxMeasure.ensure_barline(mnxdom::BarlineType::Regular);
                 } else if (!isForFinalMeasure && musxBarlineOptions->drawDoubleBarlineBeforeKeyChanges) {
                     if (const auto& nextMeasure = musxMeasure->getDocument()->getOthers()->get<others::Measure>(
                             SCORE_PARTID, static_cast<Cmper>(musxMeasure->getCmper() + 1))) {
                         if (!musxMeasure->createKeySignature()->isSame(*nextMeasure->createKeySignature().get())) {
-                            mnxMeasure.ensure_barline(mnx::BarlineType::Double);
+                            mnxMeasure.ensure_barline(mnxdom::BarlineType::Double);
                         }
                     }
                 }
                 break;
             default:
-                mnxMeasure.ensure_barline(enumConvert<mnx::BarlineType>(musxMeasure->barlineType));
+                mnxMeasure.ensure_barline(enumConvert<mnxdom::BarlineType>(musxMeasure->barlineType));
                 break;
         }
     } else {
-        mnxMeasure.ensure_barline(mnx::BarlineType::NoBarline);
+        mnxMeasure.ensure_barline(mnxdom::BarlineType::NoBarline);
     }
 }
 
-static void createEnding(mnx::global::Measure& mnxMeasure, const MusxInstance<others::Measure>& musxMeasure)
+static void createEnding(mnxdom::global::Measure& mnxMeasure, const MusxInstance<others::Measure>& musxMeasure)
 {
     if (musxMeasure->hasEnding) {
         if (auto musxEnding = musxMeasure->getDocument()->getOthers()->get<others::RepeatEndingStart>(SCORE_PARTID, musxMeasure->getCmper())) {
@@ -108,7 +110,7 @@ static std::optional<MusxInstance<others::TextRepeatAssign>> searchForJump(const
 
 static void createFine(
     const MnxMusxMappingPtr& context,
-    mnx::global::Measure& mnxMeasure,
+    mnxdom::global::Measure& mnxMeasure,
     const MusxInstance<others::Measure>& musxMeasure)
 {
     if (auto repeatAssign = searchForJump(context, classify::Jump::Fine, musxMeasure)) {
@@ -119,14 +121,14 @@ static void createFine(
 
 static void createJump(
     const MnxMusxMappingPtr& context,
-    mnx::global::Measure& mnxMeasure,
+    mnxdom::global::Measure& mnxMeasure,
     const MusxInstance<others::Measure>& musxMeasure)
 {
-    constexpr auto jumpMapping = std::to_array<std::pair<classify::Jump, mnx::JumpType>>(
+    constexpr auto jumpMapping = std::to_array<std::pair<classify::Jump, mnxdom::JumpType>>(
     {
-        {classify::Jump::DalSegno, mnx::JumpType::Segno},
-        {classify::Jump::DsAlCoda, mnx::JumpType::Segno},
-        {classify::Jump::DsAlFine, mnx::JumpType::DsAlFine},
+        {classify::Jump::DalSegno, mnxdom::JumpType::Segno},
+        {classify::Jump::DsAlCoda, mnxdom::JumpType::Segno},
+        {classify::Jump::DsAlFine, mnxdom::JumpType::DsAlFine},
     });
 
     for (const auto& mapping : jumpMapping) {
@@ -138,7 +140,7 @@ static void createJump(
 }
 
 static void assignKey(
-    mnx::global::Measure& mnxMeasure,
+    mnxdom::global::Measure& mnxMeasure,
     const MusxInstance<others::Measure>& musxMeasure,
     std::optional<int>& prevKeyFifths)
 {
@@ -149,7 +151,7 @@ static void assignKey(
     }
 }
 
-static void assignDisplayNumber(mnx::global::Measure& mnxMeasure, const MusxInstance<others::Measure>& musxMeasure)
+static void assignDisplayNumber(mnxdom::global::Measure& mnxMeasure, const MusxInstance<others::Measure>& musxMeasure)
 {
     if (const auto displayNumber = musxMeasure->calcDisplayNumber()) {
         if (displayNumber.value() != musxMeasure->getCmper()) {
@@ -158,7 +160,7 @@ static void assignDisplayNumber(mnx::global::Measure& mnxMeasure, const MusxInst
     }
 }
 
-static void assignRepeats(mnx::global::Measure& mnxMeasure, const MusxInstance<others::Measure>& musxMeasure)
+static void assignRepeats(mnxdom::global::Measure& mnxMeasure, const MusxInstance<others::Measure>& musxMeasure)
 {
     if (musxMeasure->forwardRepeatBar) {
         mnxMeasure.ensure_repeatStart();
@@ -171,7 +173,7 @@ static void assignRepeats(mnx::global::Measure& mnxMeasure, const MusxInstance<o
 
 static void createSegno(
     const MnxMusxMappingPtr& context,
-    mnx::global::Measure& mnxMeasure,
+    mnxdom::global::Measure& mnxMeasure,
     const MusxInstance<others::Measure>& musxMeasure)
 {
     if (auto repeatAssign = searchForJump(context, classify::Jump::Segno, musxMeasure)) {
@@ -187,7 +189,7 @@ static void createSegno(
     }
 }
 
-static void createTempos(const MnxMusxMappingPtr& context, mnx::global::Measure& mnxMeasure, const MusxInstance<others::Measure>& musxMeasure)
+static void createTempos(const MnxMusxMappingPtr& context, mnxdom::global::Measure& mnxMeasure, const MusxInstance<others::Measure>& musxMeasure)
 {
     auto createTempo = [&mnxMeasure](int bpm, Edu noteValue, Edu eduPosition) {
         auto mnxTempos = mnxMeasure.ensure_tempos();
@@ -251,7 +253,7 @@ static void createTempos(const MnxMusxMappingPtr& context, mnx::global::Measure&
 
 static void assignTimeSignature(
     const MnxMusxMappingPtr& context,
-    mnx::global::Measure& mnxMeasure,
+    mnxdom::global::Measure& mnxMeasure,
     const MusxInstance<others::Measure>& musxMeasure,
     MusxInstance<TimeSignature>& prevTimeSig)
 {
@@ -268,12 +270,12 @@ static void assignTimeSignature(
                     << " has fractional portion that could not be reduced.", MessageSeverity::Warning);
             }
         }
-        mnxMeasure.ensure_time(count.quotient(), enumConvert<mnx::TimeSignatureUnit>(noteType));
+        mnxMeasure.ensure_time(count.quotient(), enumConvert<mnxdom::TimeSignatureUnit>(noteType));
         prevTimeSig = timeSig;
     }
 }
 
-static void createBarlineFermata(const MnxMusxMappingPtr& context, mnx::global::Measure& mnxMeasure, const MusxInstance<others::Measure>& musxMeasure)
+static void createBarlineFermata(const MnxMusxMappingPtr& context, mnxdom::global::Measure& mnxMeasure, const MusxInstance<others::Measure>& musxMeasure)
 {
     const auto& musxDocument = context->document;
     const auto forPartId = musxMeasure->getRequestedPartId();
@@ -341,7 +343,7 @@ static void createLyricsGlobal(const MnxMusxMappingPtr& context)
             auto mnxLineMetadata = mnxLyrics.lineMetadata().value();
             std::string lineId = calcLyricLineId(std::string(T::XmlNodeName), musxLyric->getTextNumber());
             context->lyricLineIds.emplace(lineId);
-            mnx::global::LyricLineMetadata metaData = mnxLineMetadata.append(lineId);
+            mnxdom::global::LyricLineMetadata metaData = mnxLineMetadata.append(lineId);
             std::string mnxLabel = std::string(T::XmlNodeName) + " " + std::to_string(musxLyric->getTextNumber());
             mnxLabel[0] = char(std::toupper(mnxLabel[0]));
             metaData.set_label(mnxLabel);
@@ -405,5 +407,7 @@ void createGlobal(const MnxMusxMappingPtr& context)
     createGlobalMeasures(context);
 }
 
-} // namespace mnxexp
+} // namespace detail
+} // namespace mnx
+} // namespace formats
 } // namespace denigma

--- a/src/formats/mnx/mnx_layouts.cpp
+++ b/src/formats/mnx/mnx_layouts.cpp
@@ -27,10 +27,12 @@
 #include "mnx.h"
 
 namespace denigma {
-namespace mnxexp {
+namespace formats {
+namespace mnx {
+namespace detail {
 
 // Helper function to create a JSON representation of a single staff
-static void buildMnxStaff(mnx::layout::Staff&& mnxStaff,
+static void buildMnxStaff(mnxdom::layout::Staff&& mnxStaff,
     const MnxMusxMappingPtr& context,
     const MusxInstance<others::Measure>& meas,
     const MusxInstance<others::StaffUsed>& staffSlot)
@@ -58,7 +60,7 @@ static void buildMnxStaff(mnx::layout::Staff&& mnxStaff,
                 if (staff->masks->fullName) {
                     mnxSource.set_label(staff->getFullInstrumentName());
                 } else {
-                    mnxSource.set_labelref(mnx::LabelRef::Name);
+                    mnxSource.set_labelref(mnxdom::LabelRef::Name);
                 }
             }
         } else {
@@ -68,7 +70,7 @@ static void buildMnxStaff(mnx::layout::Staff&& mnxStaff,
                 if (staff->masks->abrvName) {
                     mnxSource.set_label(staff->getAbbreviatedInstrumentName());
                 } else {
-                    mnxSource.set_labelref(mnx::LabelRef::ShortName);                    
+                    mnxSource.set_labelref(mnxdom::LabelRef::ShortName);                    
                 }
             }
         }
@@ -81,10 +83,10 @@ static void buildMnxStaff(mnx::layout::Staff&& mnxStaff,
         default:
             break;
         case StemDirection::AlwaysUp:
-            mnxSource.set_stem(mnx::StemDirection::Up);
+            mnxSource.set_stem(mnxdom::StemDirection::Up);
             break;
         case StemDirection::AlwaysDown:
-            mnxSource.set_stem(mnx::StemDirection::Down);
+            mnxSource.set_stem(mnxdom::StemDirection::Down);
             break;
         }
     }
@@ -114,7 +116,7 @@ static bool hasInstrumentStaffGroupMapping(
 }
 
 static void buildOrderedContent(
-    mnx::layout::LayoutContent&& content,
+    mnxdom::layout::LayoutContent&& content,
     const MnxMusxMappingPtr& context,
     const std::vector<details::StaffGroupInfo>& groups,
     const MusxInstanceList<others::StaffUsed>& systemStaves,
@@ -135,15 +137,15 @@ static void buildOrderedContent(
             auto mnxGroup = content.appendGroup();
             switch (group.group->drawBarlines) {
             case details::StaffGroup::DrawBarlineStyle::OnlyOnStaves:
-                mnxGroup.set_or_clear_barlineStyle(mnx::StaffGroupBarlineStyle::Individual);
+                mnxGroup.set_or_clear_barlineStyle(mnxdom::StaffGroupBarlineStyle::Individual);
                 break;
             case details::StaffGroup::DrawBarlineStyle::ThroughStaves:
                 mnxGroup.set_or_clear_barlineStyle(hasInstrumentStaffGroupMapping(context, group)
-                    ? mnx::StaffGroupBarlineStyle::Instrument
-                    : mnx::StaffGroupBarlineStyle::Unified);
+                    ? mnxdom::StaffGroupBarlineStyle::Instrument
+                    : mnxdom::StaffGroupBarlineStyle::Unified);
                 break;
             case details::StaffGroup::DrawBarlineStyle::Mensurstriche:
-                mnxGroup.set_or_clear_barlineStyle(mnx::StaffGroupBarlineStyle::Mensurstrich);
+                mnxGroup.set_or_clear_barlineStyle(mnxdom::StaffGroupBarlineStyle::Mensurstrich);
                 break;
             }
             if (!group.group->hideName) {
@@ -160,10 +162,10 @@ static void buildOrderedContent(
                     break;
                 case details::Bracket::BracketStyle::DeskBracket: // until mnx provides a proper desk bracket.
                 case details::Bracket::BracketStyle::PianoBrace:
-                    mnxGroup.set_symbol(mnx::LayoutSymbol::Brace);
+                    mnxGroup.set_symbol(mnxdom::LayoutSymbol::Brace);
                     break;
                 default:
-                    mnxGroup.set_symbol(mnx::LayoutSymbol::Bracket);
+                    mnxGroup.set_symbol(mnxdom::LayoutSymbol::Bracket);
                     break;
                 }
             }
@@ -232,5 +234,7 @@ void createLayouts(const MnxMusxMappingPtr& context)
     }
 }
 
-} // namespace mnxexp
+} // namespace detail
+} // namespace mnx
+} // namespace formats
 } // namespace denigma

--- a/src/formats/mnx/mnx_mapping.cpp
+++ b/src/formats/mnx/mnx_mapping.cpp
@@ -22,15 +22,17 @@
 #include "mnx.h"
 
 namespace denigma {
-namespace mnxexp {
+namespace formats {
+namespace mnx {
+namespace detail {
 
-mnx::NoteValue::Required mnxNoteValueFromEdu(Edu duration)
+mnxdom::NoteValue::Required mnxNoteValueFromEdu(Edu duration)
 {
     auto [base, dots] = calcDurationInfoFromEdu(duration);
-    return mnx::NoteValue::make(enumConvert<mnx::NoteValueBase>(base), dots);
+    return mnxdom::NoteValue::make(enumConvert<mnxdom::NoteValueBase>(base), dots);
 }
 
-mnx::NoteValueQuantity::Required mnxNoteValueQuantityFromFraction(const MnxMusxMappingPtr& context, musx::util::Fraction duration)
+mnxdom::NoteValueQuantity::Required mnxNoteValueQuantityFromFraction(const MnxMusxMappingPtr& context, musx::util::Fraction duration)
 {
     if (duration <= 0 || (duration.denominator() & (duration.denominator() - 1)) != 0) {
         auto newValue = musx::util::Fraction(duration.calcEduDuration(), Edu(musx::dom::NoteType::Whole));
@@ -39,27 +41,27 @@ mnx::NoteValueQuantity::Required mnxNoteValueQuantityFromFraction(const MnxMusxM
         duration = newValue;
     }
 
-    return mnx::NoteValueQuantity::make(
+    return mnxdom::NoteValueQuantity::make(
         static_cast<unsigned>(duration.numerator()),
         mnxNoteValueFromEdu(musx::util::Fraction(1, duration.denominator()).calcEduDuration()));
 }
 
-musx::util::Fraction fractionFromMnxFraction(const mnx::FractionValue& mnxFraction)
+musx::util::Fraction fractionFromMnxFraction(const mnxdom::FractionValue& mnxFraction)
 {
     return musx::util::Fraction(mnxFraction.numerator(), mnxFraction.denominator());
 }
 
-mnx::FractionValue mnxFractionFromFraction(const musx::util::Fraction& fraction)
+mnxdom::FractionValue mnxFractionFromFraction(const musx::util::Fraction& fraction)
 {
-    return mnx::FractionValue(fraction.numerator(), fraction.denominator());
+    return mnxdom::FractionValue(fraction.numerator(), fraction.denominator());
 }
 
-mnx::FractionValue mnxFractionFromEdu(Edu eduValue)
+mnxdom::FractionValue mnxFractionFromEdu(Edu eduValue)
 {
     return mnxFractionFromFraction(musx::util::Fraction::fromEdu(eduValue));
 }
 
-mnx::FractionValue mnxFractionFromSmartShapeEndPoint(const MusxInstance<smartshape::EndPoint>& endPoint)
+mnxdom::FractionValue mnxFractionFromSmartShapeEndPoint(const MusxInstance<smartshape::EndPoint>& endPoint)
 {
     // findExact true needed for ottavas. revisit as we add other items.
     if (auto entryInfo = endPoint->calcAssociatedEntry(/*findExact*/ true)) {
@@ -73,34 +75,36 @@ int mnxStaffPosition(const MusxInstance<others::Staff>& staff, int musxStaffPosi
     return musxStaffPosition - staff->calcMiddleStaffPosition();
 }
 
-mnx::LyricLineType mnxLineTypeFromLyric(const MusxInstance<LyricsSyllableInfo>& syl)
+mnxdom::LyricLineType mnxLineTypeFromLyric(const MusxInstance<LyricsSyllableInfo>& syl)
 {
     if (syl->hasHyphenBefore && syl->hasHyphenAfter) {
-        return mnx::LyricLineType::Middle;
+        return mnxdom::LyricLineType::Middle;
     } else if (syl->hasHyphenBefore && !syl->hasHyphenAfter) {
-        return mnx::LyricLineType::End;
+        return mnxdom::LyricLineType::End;
     } else if (!syl->hasHyphenBefore && syl->hasHyphenAfter) {
-        return mnx::LyricLineType::Start;
+        return mnxdom::LyricLineType::Start;
     }
-    return mnx::LyricLineType::Whole;
+    return mnxdom::LyricLineType::Whole;
 }
 
-mnx::MultiStaffOrientation mnxMultiStaffOrientFromVerticalPlacement(const std::optional<int>& mnxStaffNumber, VerticalPlacement placement)
+mnxdom::MultiStaffOrientation mnxMultiStaffOrientFromVerticalPlacement(const std::optional<int>& mnxStaffNumber, VerticalPlacement placement)
 {
-    auto result = enumConvert<mnx::MultiStaffOrientation>(placement);
+    auto result = enumConvert<mnxdom::MultiStaffOrientation>(placement);
     if (mnxStaffNumber.has_value()) {
         if (mnxStaffNumber == 1) {
             if (placement == VerticalPlacement::Below) {
-                result = mnx::MultiStaffOrientation::Between;
+                result = mnxdom::MultiStaffOrientation::Between;
             }
         } else {
             if (placement == VerticalPlacement::Above) {
-                result = mnx::MultiStaffOrientation::Between;
+                result = mnxdom::MultiStaffOrientation::Between;
             }
         }
     }
     return result;
 }
 
-} // namespace mnxexp
+} // namespace detail
+} // namespace mnx
+} // namespace formats
 } // namespace denigma

--- a/src/formats/mnx/mnx_mapping.h
+++ b/src/formats/mnx/mnx_mapping.h
@@ -34,22 +34,26 @@ using namespace musx::dom;
 using namespace musx::util;
 
 namespace denigma {
-namespace mnxexp {
+namespace formats {
+namespace mnx {
+namespace detail {
 
 struct MnxMusxMapping;
 
-mnx::NoteValue::Required mnxNoteValueFromEdu(Edu duration);
-mnx::NoteValueQuantity::Required mnxNoteValueQuantityFromFraction(const std::shared_ptr<MnxMusxMapping>& context, musx::util::Fraction duration);
-mnx::LyricLineType mnxLineTypeFromLyric(const MusxInstance<LyricsSyllableInfo>& syl);
+mnxdom::NoteValue::Required mnxNoteValueFromEdu(Edu duration);
+mnxdom::NoteValueQuantity::Required mnxNoteValueQuantityFromFraction(const std::shared_ptr<MnxMusxMapping>& context, musx::util::Fraction duration);
+mnxdom::LyricLineType mnxLineTypeFromLyric(const MusxInstance<LyricsSyllableInfo>& syl);
 
-musx::util::Fraction fractionFromMnxFraction(const mnx::FractionValue& mnxFraction);
-mnx::FractionValue mnxFractionFromFraction(const musx::util::Fraction& fraction);
-mnx::FractionValue mnxFractionFromEdu(Edu eduValue);
-mnx::FractionValue mnxFractionFromSmartShapeEndPoint(const MusxInstance<smartshape::EndPoint>& smartShape);
+musx::util::Fraction fractionFromMnxFraction(const mnxdom::FractionValue& mnxFraction);
+mnxdom::FractionValue mnxFractionFromFraction(const musx::util::Fraction& fraction);
+mnxdom::FractionValue mnxFractionFromEdu(Edu eduValue);
+mnxdom::FractionValue mnxFractionFromSmartShapeEndPoint(const MusxInstance<smartshape::EndPoint>& smartShape);
 
 int mnxStaffPosition(const MusxInstance<others::Staff>& staff, int musxStaffPosition);
 
-mnx::MultiStaffOrientation mnxMultiStaffOrientFromVerticalPlacement(const std::optional<int>& mnxStaffNumber, VerticalPlacement placement);
+mnxdom::MultiStaffOrientation mnxMultiStaffOrientFromVerticalPlacement(const std::optional<int>& mnxStaffNumber, VerticalPlacement placement);
 
-} // namespace mnxexp
+} // namespace detail
+} // namespace mnx
+} // namespace formats
 } // namespace denigma

--- a/src/formats/mnx/mnx_markings.cpp
+++ b/src/formats/mnx/mnx_markings.cpp
@@ -30,9 +30,11 @@
 #include "utils/utf8_iterator.h"
 
 namespace denigma {
-namespace mnxexp {
+namespace formats {
+namespace mnx {
+namespace detail {
 
-mnx::MarkingUpDownAuto calcPointing(const std::string_view glyphName, VerticalPlacement placement)
+mnxdom::MarkingUpDownAuto calcPointing(const std::string_view glyphName, VerticalPlacement placement)
 {
     const auto endsWith = [&](const std::string_view suffix) {
         return glyphName.size() >= suffix.size()
@@ -43,30 +45,30 @@ mnx::MarkingUpDownAuto calcPointing(const std::string_view glyphName, VerticalPl
     switch (placement) {
     case VerticalPlacement::Above:
         if (glyphIsBelow) {
-            return mnx::MarkingUpDownAuto::Down;
+            return mnxdom::MarkingUpDownAuto::Down;
         }
         break;
     case VerticalPlacement::Below:
         if (glyphIsAbove) {
-            return mnx::MarkingUpDownAuto::Up;
+            return mnxdom::MarkingUpDownAuto::Up;
         }
         break;
     case VerticalPlacement::Float:
     case VerticalPlacement::NotApplicable:
         break;
     }
-    return mnx::MarkingUpDownAuto::Auto;
+    return mnxdom::MarkingUpDownAuto::Auto;
 }
 
-mnx::MarkingUpDownAuto calcPointing(const MusxInstance<FontInfo>& fontInfo, char32_t sym, VerticalPlacement placement)
+mnxdom::MarkingUpDownAuto calcPointing(const MusxInstance<FontInfo>& fontInfo, char32_t sym, VerticalPlacement placement)
 {
     if (const auto glyphName = utils::smuflGlyphNameForFont(fontInfo, sym)) {
         return calcPointing(glyphName.value(), placement);
     }
-    return mnx::MarkingUpDownAuto::Auto;
+    return mnxdom::MarkingUpDownAuto::Auto;
 }
 
-std::optional<mnx::Fermata> makeFermata(const classify::Fermata& fermata, const std::optional<std::string>& glyphName, VerticalPlacement placement)
+std::optional<mnxdom::Fermata> makeFermata(const classify::Fermata& fermata, const std::optional<std::string>& glyphName, VerticalPlacement placement)
 {
     if (placement == VerticalPlacement::NotApplicable) {
         return std::nullopt;
@@ -74,53 +76,53 @@ std::optional<mnx::Fermata> makeFermata(const classify::Fermata& fermata, const 
 
     auto convertSymbol = [](classify::Fermata::Shape shape) {
         switch (shape) {
-        case classify::Fermata::Shape::Normal: return mnx::FermataSymbol::Normal;
-        case classify::Fermata::Shape::Angled: return mnx::FermataSymbol::Angled;
-        case classify::Fermata::Shape::DoubleAngled: return mnx::FermataSymbol::DoubleAngled;
-        case classify::Fermata::Shape::Square: return mnx::FermataSymbol::Square;
-        case classify::Fermata::Shape::DoubleSquare: return mnx::FermataSymbol::DoubleSquare;
-        case classify::Fermata::Shape::HalfCurve: return mnx::FermataSymbol::HalfCurve;
-        case classify::Fermata::Shape::DoubleDot: return mnx::FermataSymbol::DoubleDot;
-        case classify::Fermata::Shape::Curlew: return mnx::FermataSymbol::Curlew;
+        case classify::Fermata::Shape::Normal: return mnxdom::FermataSymbol::Normal;
+        case classify::Fermata::Shape::Angled: return mnxdom::FermataSymbol::Angled;
+        case classify::Fermata::Shape::DoubleAngled: return mnxdom::FermataSymbol::DoubleAngled;
+        case classify::Fermata::Shape::Square: return mnxdom::FermataSymbol::Square;
+        case classify::Fermata::Shape::DoubleSquare: return mnxdom::FermataSymbol::DoubleSquare;
+        case classify::Fermata::Shape::HalfCurve: return mnxdom::FermataSymbol::HalfCurve;
+        case classify::Fermata::Shape::DoubleDot: return mnxdom::FermataSymbol::DoubleDot;
+        case classify::Fermata::Shape::Curlew: return mnxdom::FermataSymbol::Curlew;
         }
         throw std::logic_error("Unhandled fermata shape.");
     };
     auto convertDuration = [](classify::Fermata::Duration duration) {
         switch (duration) {
-        case classify::Fermata::Duration::Auto: return mnx::FermataDuration::Auto;
-        case classify::Fermata::Duration::VeryShort: return mnx::FermataDuration::VeryShort;
-        case classify::Fermata::Duration::Short: return mnx::FermataDuration::Short;
-        case classify::Fermata::Duration::Long: return mnx::FermataDuration::Long;
-        case classify::Fermata::Duration::VeryLong: return mnx::FermataDuration::VeryLong;
+        case classify::Fermata::Duration::Auto: return mnxdom::FermataDuration::Auto;
+        case classify::Fermata::Duration::VeryShort: return mnxdom::FermataDuration::VeryShort;
+        case classify::Fermata::Duration::Short: return mnxdom::FermataDuration::Short;
+        case classify::Fermata::Duration::Long: return mnxdom::FermataDuration::Long;
+        case classify::Fermata::Duration::VeryLong: return mnxdom::FermataDuration::VeryLong;
         }
         throw std::logic_error("Unhandled fermata duration.");
     };
 
-    mnx::Fermata result;
+    mnxdom::Fermata result;
     result.set_or_clear_symbol(convertSymbol(fermata.shape));
     result.set_or_clear_duration(convertDuration(fermata.duration));
-    result.set_or_clear_orient(enumConvert<mnx::Orientation>(placement));
+    result.set_or_clear_orient(enumConvert<mnxdom::Orientation>(placement));
     if (glyphName) {
         result.set_or_clear_pointing(calcPointing(glyphName.value(), placement));
     }
     return result;
 }
 
-std::optional<mnx::sequence::BreathMark> makeBreathMark(const classify::BreathMark& breathMark, VerticalPlacement placement)
+std::optional<mnxdom::sequence::BreathMark> makeBreathMark(const classify::BreathMark& breathMark, VerticalPlacement placement)
 {
-    std::optional<mnx::BreathMarkSymbol> symbol;
+    std::optional<mnxdom::BreathMarkSymbol> symbol;
     switch (breathMark.type) {
     case classify::BreathMark::Type::Comma:
-        symbol = mnx::BreathMarkSymbol::Comma;
+        symbol = mnxdom::BreathMarkSymbol::Comma;
         break;
     case classify::BreathMark::Type::Tick:
-        symbol = mnx::BreathMarkSymbol::Tick;
+        symbol = mnxdom::BreathMarkSymbol::Tick;
         break;
     case classify::BreathMark::Type::Upbow:
-        symbol = mnx::BreathMarkSymbol::Upbow;
+        symbol = mnxdom::BreathMarkSymbol::Upbow;
         break;
     case classify::BreathMark::Type::Salzedo:
-        symbol = mnx::BreathMarkSymbol::Salzedo;
+        symbol = mnxdom::BreathMarkSymbol::Salzedo;
         break;
     case classify::BreathMark::Type::Caesura:
     case classify::BreathMark::Type::CaesuraCurved:
@@ -133,9 +135,9 @@ std::optional<mnx::sequence::BreathMark> makeBreathMark(const classify::BreathMa
     if (!symbol) {
         return std::nullopt;
     }
-    mnx::sequence::BreathMark result;
+    mnxdom::sequence::BreathMark result;
     result.set_symbol(symbol.value());
-    result.set_or_clear_orient(enumConvert<mnx::Orientation>(placement));
+    result.set_or_clear_orient(enumConvert<mnxdom::Orientation>(placement));
     return result;
 }
 
@@ -239,7 +241,7 @@ static std::optional<NoteInfoPtr> findArpeggioBoundaryNoteInCurrentPart(
     return findInEntry(fallbackEntry);
 }
 
-static void setArpeggioGraceIndex(mnx::RhythmicPosition position, const musx::util::ArpeggioSpanCandidate& candidate)
+static void setArpeggioGraceIndex(mnxdom::RhythmicPosition position, const musx::util::ArpeggioSpanCandidate& candidate)
 {
     if (candidate.sourceEntry->graceIndex) {
         position.set_graceIndex(candidate.sourceEntry.calcReverseGraceIndex());
@@ -248,7 +250,7 @@ static void setArpeggioGraceIndex(mnx::RhythmicPosition position, const musx::ut
     }
 }
 
-static void appendArpeggio(const NoteInfoPtr& topNote, const NoteInfoPtr& bottomNote, mnx::part::Measure& mnxPartMeasure,
+static void appendArpeggio(const NoteInfoPtr& topNote, const NoteInfoPtr& bottomNote, mnxdom::part::Measure& mnxPartMeasure,
     const musx::util::ArpeggioSpanCandidate& candidate)
 {
     const auto startId = [&]() -> std::string {
@@ -280,18 +282,18 @@ static void appendArpeggio(const NoteInfoPtr& topNote, const NoteInfoPtr& bottom
 
     auto mnxArpeggio = mnxPartMeasure.ensure_arpeggios().append(
         mnxFractionFromFraction(candidate.sourceEntry.calcGlobalElapsedDuration()),
-        mnx::IdPair::make(startId, endId));
+        mnxdom::IdPair::make(startId, endId));
     setArpeggioGraceIndex(mnxArpeggio.position(), candidate);
 
     switch (candidate.direction) {
     case musx::util::ArpeggioDirection::Auto:
-        mnxArpeggio.set_or_clear_direction(mnx::MarkingUpDownAuto::Auto);
+        mnxArpeggio.set_or_clear_direction(mnxdom::MarkingUpDownAuto::Auto);
         break;
     case musx::util::ArpeggioDirection::Up:
-        mnxArpeggio.set_or_clear_direction(mnx::MarkingUpDownAuto::Up);
+        mnxArpeggio.set_or_clear_direction(mnxdom::MarkingUpDownAuto::Up);
         break;
     case musx::util::ArpeggioDirection::Down:
-        mnxArpeggio.set_or_clear_direction(mnx::MarkingUpDownAuto::Down);
+        mnxArpeggio.set_or_clear_direction(mnxdom::MarkingUpDownAuto::Down);
         break;
     }
 
@@ -307,16 +309,16 @@ static void appendArpeggio(const NoteInfoPtr& topNote, const NoteInfoPtr& bottom
     }
 }
 
-static void appendNonArpeggio(const NoteInfoPtr& topNote, const NoteInfoPtr& bottomNote, mnx::part::Measure& mnxPartMeasure,
+static void appendNonArpeggio(const NoteInfoPtr& topNote, const NoteInfoPtr& bottomNote, mnxdom::part::Measure& mnxPartMeasure,
     const musx::util::ArpeggioSpanCandidate& candidate)
 {
     auto mnxNonArpeggio = mnxPartMeasure.ensure_nonArpeggios().append(
         mnxFractionFromFraction(candidate.sourceEntry.calcGlobalElapsedDuration()),
-        mnx::IdPair::make(calcNoteId(bottomNote), calcNoteId(topNote)));
+        mnxdom::IdPair::make(calcNoteId(bottomNote), calcNoteId(topNote)));
     setArpeggioGraceIndex(mnxNonArpeggio.position(), candidate);
 }
 
-static void appendArpeggioOrNonArpeggio(const NoteInfoPtr& topNote, const NoteInfoPtr& bottomNote, mnx::part::Measure& mnxPartMeasure,
+static void appendArpeggioOrNonArpeggio(const NoteInfoPtr& topNote, const NoteInfoPtr& bottomNote, mnxdom::part::Measure& mnxPartMeasure,
     const musx::util::ArpeggioSpanCandidate& candidate)
 {
     using SpanType = musx::util::ArpeggioSpanType;
@@ -330,7 +332,7 @@ static void appendArpeggioOrNonArpeggio(const NoteInfoPtr& topNote, const NoteIn
     }
 }
 
-void appendArpeggioCandidate(const MnxMusxMappingPtr& context, mnx::part::Measure&,
+void appendArpeggioCandidate(const MnxMusxMappingPtr& context, mnxdom::part::Measure&,
     const musx::util::ArpeggioSpanCandidate& candidate)
 {
     const auto topNote = findArepggioBoundaryNote(candidate.topEntry, true);
@@ -457,5 +459,7 @@ void finalizeArpeggios(const MnxMusxMappingPtr& context)
     }
 }
 
-} // namespace mnxexp
+} // namespace detail
+} // namespace mnx
+} // namespace formats
 } // namespace denigma

--- a/src/formats/mnx/mnx_markings.h
+++ b/src/formats/mnx/mnx_markings.h
@@ -33,21 +33,25 @@ using namespace musx::dom;
 using namespace musx::util;
 
 namespace denigma {
-namespace mnxexp {
+namespace formats {
+namespace mnx {
+namespace detail {
 
-mnx::MarkingUpDownAuto calcPointing(const std::string_view glyphName, VerticalPlacement placement);
-mnx::MarkingUpDownAuto calcPointing(const MusxInstance<FontInfo>& fontInfo, char32_t sym, VerticalPlacement placement);
+mnxdom::MarkingUpDownAuto calcPointing(const std::string_view glyphName, VerticalPlacement placement);
+mnxdom::MarkingUpDownAuto calcPointing(const MusxInstance<FontInfo>& fontInfo, char32_t sym, VerticalPlacement placement);
 
-std::optional<mnx::Fermata> makeFermata(const classify::Fermata& fermata, const std::optional<std::string>& glyphName, VerticalPlacement placement);
+std::optional<mnxdom::Fermata> makeFermata(const classify::Fermata& fermata, const std::optional<std::string>& glyphName, VerticalPlacement placement);
 
-std::optional<mnx::sequence::BreathMark> makeBreathMark(const classify::BreathMark& breathMark, VerticalPlacement placement);
+std::optional<mnxdom::sequence::BreathMark> makeBreathMark(const classify::BreathMark& breathMark, VerticalPlacement placement);
 
 std::optional<musx::util::ArpeggioSpanCandidate> makeArpeggio(
     const EntryInfoPtr& sourceEntry,
     const MusxInstance<details::ArticulationAssign>& assign,
     const classify::Arpeggio& arpeggio);
-void appendArpeggioCandidate(const MnxMusxMappingPtr& context, mnx::part::Measure& mnxPartMeasure, const musx::util::ArpeggioSpanCandidate& candidate);
+void appendArpeggioCandidate(const MnxMusxMappingPtr& context, mnxdom::part::Measure& mnxPartMeasure, const musx::util::ArpeggioSpanCandidate& candidate);
 void finalizeArpeggios(const MnxMusxMappingPtr& context);
 
-} // namespace mnxexp
+} // namespace detail
+} // namespace mnx
+} // namespace formats
 } // namespace denigma

--- a/src/formats/mnx/mnx_parts.cpp
+++ b/src/formats/mnx/mnx_parts.cpp
@@ -34,22 +34,24 @@
 #include "denigma/classify/dynamics.h"
 
 namespace denigma {
-namespace mnxexp {
+namespace formats {
+namespace mnx {
+namespace detail {
 
 static void createBeams(
     const MnxMusxMappingPtr& context,
-    mnx::part::Measure mnxMeasure,
+    mnxdom::part::Measure mnxMeasure,
     const MusxInstance<others::Measure>& musxMeasure)
 {
     const auto& musxDocument = musxMeasure->getDocument();
-    const auto mnxMeasures = mnxMeasure.parent<mnx::Array<mnx::part::Measure>>();
+    const auto mnxMeasures = mnxMeasure.parent<mnxdom::Array<mnxdom::part::Measure>>();
     const auto partId = musxMeasure->getRequestedPartId();
     if (context->current.gfhold) {
         if (context->current.cueDiscardPlan.discardWholeHold) {
             return; // skip cues until MNX spec includes them
         }
         auto processEntry = [&](const EntryInfoPtr& entryInfo) -> bool {
-            auto processBeam = [&](mnx::Array<mnx::part::Beam>&& mnxBeams, unsigned beamNumber, const EntryInfoPtr& firstInBeam, auto&& self) -> void {
+            auto processBeam = [&](mnxdom::Array<mnxdom::part::Beam>&& mnxBeams, unsigned beamNumber, const EntryInfoPtr& firstInBeam, auto&& self) -> void {
                 assert(firstInBeam.calcLowestBeamStart(/*considerBeamOverBarlines*/true) <= beamNumber);
                 auto beam = mnxBeams.append();
                 for (auto next = firstInBeam; next; next = next.getNextInBeamGroupAcrossBars(EntryInfoPtr::BeamIterationMode::Interpreted)) {
@@ -65,9 +67,9 @@ static void createBeams(
                             hookBeam.events().push_back(calcEventId(entryNumber));
                             if (entry->stemDetail) {
                                 if (auto manual = musxDocument->getDetails()->get<details::BeamStubDirection>(partId, entryNumber)) {
-                                    mnx::BeamHookDirection hookDir = manual->isLeft()
-                                                                     ? mnx::BeamHookDirection::Left
-                                                                     : mnx::BeamHookDirection::Right;
+                                    mnxdom::BeamHookDirection hookDir = manual->isLeft()
+                                                                     ? mnxdom::BeamHookDirection::Left
+                                                                     : mnxdom::BeamHookDirection::Right;
                                     hookBeam.set_direction(hookDir);
                                 }
                             }
@@ -122,7 +124,7 @@ static void createBeams(
 
 static std::optional<ClefIndex> createClef(
     const MnxMusxMappingPtr& context,
-    mnx::part::Measure& mnxMeasure,
+    mnxdom::part::Measure& mnxMeasure,
     std::optional<int> mnxStaffNumber,
     ClefIndex clefIndex,
     musx::util::Fraction location,
@@ -134,19 +136,19 @@ static std::optional<ClefIndex> createClef(
     }
     const auto& musxClef = context->finaleOptions.clefOptions->getClefDef(clefIndex);
     const auto clef = classify::classifyClef(musxClef, musxStaff);
-    std::optional<mnx::ClefSign> clefSign;
+    std::optional<mnxdom::ClefSign> clefSign;
     if (clef && !clef.isBlank && std::abs(clef.octave) <= 3) {
         switch (clef.type) {
-        case music_theory::ClefType::G: clefSign = mnx::ClefSign::GClef; break;
-        case music_theory::ClefType::C: clefSign = mnx::ClefSign::CClef; break;
-        case music_theory::ClefType::F: clefSign = mnx::ClefSign::FClef; break;
+        case music_theory::ClefType::G: clefSign = mnxdom::ClefSign::GClef; break;
+        case music_theory::ClefType::C: clefSign = mnxdom::ClefSign::CClef; break;
+        case music_theory::ClefType::F: clefSign = mnxdom::ClefSign::FClef; break;
         /// @todo handle Percussion and Tab cases when defined in mnx spec
         default: break;
         }
     }
     if (clefSign) {
         int staffPosition = mnxStaffPosition(musxStaff, musxClef->staffPosition);
-        auto mnxClef = mnxMeasure.ensure_clefs().append(clefSign.value(), staffPosition, mnx::OttavaAmountOrZero(clef.octave));
+        auto mnxClef = mnxMeasure.ensure_clefs().append(clefSign.value(), staffPosition, mnxdom::OttavaAmountOrZero(clef.octave));
         if (location) {
             mnxClef.ensure_position(mnxFractionFromFraction(location));
         }
@@ -169,8 +171,8 @@ static std::optional<ClefIndex> createClef(
 
 static void createClefs(
     const MnxMusxMappingPtr& context,
-    const mnx::Part& mnxPart,
-    mnx::part::Measure& mnxMeasure,
+    const mnxdom::Part& mnxPart,
+    mnxdom::part::Measure& mnxMeasure,
     std::optional<int> mnxStaffNumber,
     const MusxInstance<others::Measure>& musxMeasure,
     std::optional<ClefIndex>& prevClefIndex)
@@ -224,7 +226,7 @@ static MusxInstance<others::StaffComposite> findCompositeForIdentity(
     return nullptr;
 }
 
-static void createMeasures(const MnxMusxMappingPtr& context, mnx::Part& part)
+static void createMeasures(const MnxMusxMappingPtr& context, mnxdom::Part& part)
 {
     auto& musxDocument = context->document;
     context->clearCounts();
@@ -320,7 +322,7 @@ static void mapPartToInstrumentStaves(const MnxMusxMappingPtr& context, const st
 
 static void populatePartMetadata(
     const MnxMusxMappingPtr& context,
-    mnx::Part& part,
+    mnxdom::Part& part,
     const std::string& id,
     const InstrumentInfo& instInfo,
     const MusxInstance<others::StaffComposite>& staff)
@@ -342,7 +344,7 @@ static void populatePartMetadata(
     const auto [transpositionDisp, transpositionAlt] = staff->calcTranspositionInterval();
     if (transpositionDisp || transpositionAlt) {
         auto transposition = part.ensure_transposition(
-            mnx::Interval::make(transpositionDisp,
+            mnxdom::Interval::make(transpositionDisp,
                                 music_theory::calc12EdoHalfstepsInInterval(transpositionDisp, transpositionAlt)));
         if (staff->transposition && !staff->transposition->noSimplifyKey && staff->transposition->keysig) {
             transposition.set_keyFifthsFlipAt(7 * music_theory::sign(staff->transposition->keysig->adjust));
@@ -396,5 +398,7 @@ void createParts(const MnxMusxMappingPtr& context)
     }
 }
 
-} // namespace mnxexp
+} // namespace detail
+} // namespace mnx
+} // namespace formats
 } // namespace denigma

--- a/src/formats/mnx/mnx_sequences.cpp
+++ b/src/formats/mnx/mnx_sequences.cpp
@@ -30,9 +30,11 @@
 #include "utils/smufl_support.h"
 
 namespace denigma {
-namespace mnxexp {
+namespace formats {
+namespace mnx {
+namespace detail {
 
-static void appendMeasureRemainderSpaces(mnx::sequence::SequenceContent content,
+static void appendMeasureRemainderSpaces(mnxdom::sequence::SequenceContent content,
     const musx::util::Fraction& elapsedInVoice,
     const musx::util::Fraction& measureDuration)
 {
@@ -76,62 +78,62 @@ static void appendMeasureRemainderSpaces(mnx::sequence::SequenceContent content,
     }
 }
 
-static mnx::sequence::MultiNoteTremolo createMultiNoteTremolo(mnx::sequence::SequenceContent content, const musx::dom::EntryFrame::TupletInfo& tupletInfo, int marks)
+static mnxdom::sequence::MultiNoteTremolo createMultiNoteTremolo(mnxdom::sequence::SequenceContent content, const musx::dom::EntryFrame::TupletInfo& tupletInfo, int marks)
 {
     const auto& musxTuplet = tupletInfo.tuplet;
     const auto entryCount = static_cast<unsigned>(tupletInfo.numEntries());
     const Edu eduRefDuration = (musxTuplet->calcReferenceDuration() / entryCount).calcEduDuration();
     auto mnxTremolo = content.appendMultiNoteTremolo(
         marks,
-        mnx::NoteValueQuantity::make(entryCount, mnxNoteValueFromEdu(eduRefDuration)));
+        mnxdom::NoteValueQuantity::make(entryCount, mnxNoteValueFromEdu(eduRefDuration)));
     /// @todo: additional fields (like noteheads) when defined by MNX committee.
     return mnxTremolo;
 }
 
-static mnx::sequence::Tuplet createTuplet(mnx::sequence::SequenceContent content, const musx::dom::EntryFrame::TupletInfo& tupletInfo)
+static mnxdom::sequence::Tuplet createTuplet(mnxdom::sequence::SequenceContent content, const musx::dom::EntryFrame::TupletInfo& tupletInfo)
 {
     const auto& musxTuplet = tupletInfo.tuplet;
     auto mnxTuplet = content.appendTuplet(
-        mnx::NoteValueQuantity::make(
+        mnxdom::NoteValueQuantity::make(
             static_cast<unsigned>(musxTuplet->displayNumber),
             mnxNoteValueFromEdu(musxTuplet->displayDuration)),
-        mnx::NoteValueQuantity::make(
+        mnxdom::NoteValueQuantity::make(
             static_cast<unsigned>(musxTuplet->referenceNumber),
             mnxNoteValueFromEdu(musxTuplet->referenceDuration)));
 
     mnxTuplet.set_or_clear_bracket([&]() {
         if (musxTuplet->brackStyle == details::TupletDef::BracketStyle::Nothing) {
-            return mnx::AutoYesNo::No;
+            return mnxdom::AutoYesNo::No;
         }
-        return enumConvert<mnx::AutoYesNo>(musxTuplet->autoBracketStyle);
+        return enumConvert<mnxdom::AutoYesNo>(musxTuplet->autoBracketStyle);
     }());
 
     mnxTuplet.set_or_clear_showNumber([&]() {
         switch (musxTuplet->numStyle) {
-            case details::TupletDef::NumberStyle::Number: return mnx::TupletDisplaySetting::Inner;
-            case details::TupletDef::NumberStyle::Nothing: return mnx::TupletDisplaySetting::NoNumber;
-            case details::TupletDef::NumberStyle::UseRatio: return mnx::TupletDisplaySetting::Both;
-            case details::TupletDef::NumberStyle::RatioPlusDenominatorNote: return mnx::TupletDisplaySetting::Both;
-            case details::TupletDef::NumberStyle::RatioPlusBothNotes: return mnx::TupletDisplaySetting::Both;
+            case details::TupletDef::NumberStyle::Number: return mnxdom::TupletDisplaySetting::Inner;
+            case details::TupletDef::NumberStyle::Nothing: return mnxdom::TupletDisplaySetting::NoNumber;
+            case details::TupletDef::NumberStyle::UseRatio: return mnxdom::TupletDisplaySetting::Both;
+            case details::TupletDef::NumberStyle::RatioPlusDenominatorNote: return mnxdom::TupletDisplaySetting::Both;
+            case details::TupletDef::NumberStyle::RatioPlusBothNotes: return mnxdom::TupletDisplaySetting::Both;
         }
-        return mnx::TupletDisplaySetting::Inner;
+        return mnxdom::TupletDisplaySetting::Inner;
     }());
 
     mnxTuplet.set_or_clear_showValue([&]() {
         switch (musxTuplet->numStyle) {
-            case details::TupletDef::NumberStyle::Number: return mnx::TupletDisplaySetting::NoNumber;
-            case details::TupletDef::NumberStyle::Nothing: return mnx::TupletDisplaySetting::NoNumber;
-            case details::TupletDef::NumberStyle::UseRatio: return mnx::TupletDisplaySetting::NoNumber;
-            case details::TupletDef::NumberStyle::RatioPlusDenominatorNote: return mnx::TupletDisplaySetting::Inner; // should be Outer, but this is not currently an option
-            case details::TupletDef::NumberStyle::RatioPlusBothNotes: return mnx::TupletDisplaySetting::Both;
+            case details::TupletDef::NumberStyle::Number: return mnxdom::TupletDisplaySetting::NoNumber;
+            case details::TupletDef::NumberStyle::Nothing: return mnxdom::TupletDisplaySetting::NoNumber;
+            case details::TupletDef::NumberStyle::UseRatio: return mnxdom::TupletDisplaySetting::NoNumber;
+            case details::TupletDef::NumberStyle::RatioPlusDenominatorNote: return mnxdom::TupletDisplaySetting::Inner; // should be Outer, but this is not currently an option
+            case details::TupletDef::NumberStyle::RatioPlusBothNotes: return mnxdom::TupletDisplaySetting::Both;
         }
-        return mnx::TupletDisplaySetting::NoNumber;
+        return mnxdom::TupletDisplaySetting::NoNumber;
     }());
 
     return mnxTuplet;
 }
 
-static void createTies(const MnxMusxMappingPtr& context, mnx::sequence::NoteBase& mnxNote, const NoteInfoPtr& musxNote)
+static void createTies(const MnxMusxMappingPtr& context, mnxdom::sequence::NoteBase& mnxNote, const NoteInfoPtr& musxNote)
 {
     bool tieCreated = false;
     if (musxNote->tieStart) {
@@ -145,14 +147,14 @@ static void createTies(const MnxMusxMappingPtr& context, mnx::sequence::NoteBase
         }
         if (!mnxTie.lv()) {
             if (tiedTo.getEntryInfo().getVoice() == musxNote.getEntryInfo().getVoice()) {
-                mnxTie.set_targetType(mnx::TieTargetType::NextNote);
+                mnxTie.set_targetType(mnxdom::TieTargetType::NextNote);
             } else {
-                mnxTie.set_targetType(mnx::TieTargetType::CrossVoice);
+                mnxTie.set_targetType(mnxdom::TieTargetType::CrossVoice);
             }
         }
         if (auto tieAlter = context->document->getDetails()->getForNote<details::TieAlterStart>(musxNote)) {
             if (tieAlter->freezeDirection) {
-                mnxTie.set_side(tieAlter->down ? mnx::SlurTieSide::Down : mnx::SlurTieSide::Up);
+                mnxTie.set_side(tieAlter->down ? mnxdom::SlurTieSide::Down : mnxdom::SlurTieSide::Up);
             }
         }
         tieCreated = true;
@@ -163,9 +165,9 @@ static void createTies(const MnxMusxMappingPtr& context, mnx::sequence::NoteBase
         auto mnxTies = mnxNote.ensure_ties();
         auto mnxTie = mnxTies.append();
         mnxTie.set_target(calcNoteId(musxTargetNote));
-        mnxTie.set_targetType(mnx::TieTargetType::Arpeggio);
+        mnxTie.set_targetType(mnxdom::TieTargetType::Arpeggio);
         if (tiedToInfo->direction != Curve::Unspecified) {
-            mnxTie.set_side(tiedToInfo->direction == Curve::Up ? mnx::SlurTieSide::Up : mnx::SlurTieSide::Down);
+            mnxTie.set_side(tiedToInfo->direction == Curve::Up ? mnxdom::SlurTieSide::Up : mnxdom::SlurTieSide::Down);
         }
         tieCreated = true;
     }
@@ -175,7 +177,7 @@ static void createTies(const MnxMusxMappingPtr& context, mnx::sequence::NoteBase
             auto mnxTie = mnxTies.append();
             mnxTie.set_lv(true);
             if (pseudoTieInfo.direction != Curve::Unspecified) {
-                mnxTie.set_side(pseudoTieInfo.direction == Curve::Up ? mnx::SlurTieSide::Up : mnx::SlurTieSide::Down);
+                mnxTie.set_side(pseudoTieInfo.direction == Curve::Up ? mnxdom::SlurTieSide::Up : mnxdom::SlurTieSide::Down);
             }
         }
     }
@@ -213,16 +215,16 @@ static void deferJumpTies(const MnxMusxMappingPtr& context, const NoteInfoPtr& m
             std::nullopt
         };
         if (direction != CurveContourDirection::Unspecified) {
-            deferred.side = (direction == CurveContourDirection::Up) ? mnx::SlurTieSide::Up : mnx::SlurTieSide::Down;
+            deferred.side = (direction == CurveContourDirection::Up) ? mnxdom::SlurTieSide::Up : mnxdom::SlurTieSide::Down;
         }
         context->deferredJumpTies.push_back(std::move(deferred));
     }
 }
 
-static void createSlurs(const MnxMusxMappingPtr&, mnx::sequence::Event& mnxEvent, const EntryInfoPtr& musxEntryInfo)
+static void createSlurs(const MnxMusxMappingPtr&, mnxdom::sequence::Event& mnxEvent, const EntryInfoPtr& musxEntryInfo)
 {
     const auto musxEntry = musxEntryInfo->getEntry();
-    auto createOneSlur = [&](const EntryNumber targetEntry) -> mnx::sequence::Slur {
+    auto createOneSlur = [&](const EntryNumber targetEntry) -> mnxdom::sequence::Slur {
         auto mnxSlurs = mnxEvent.ensure_slurs();
         return mnxSlurs.append(calcEventId(targetEntry));
     };
@@ -235,9 +237,9 @@ static void createSlurs(const MnxMusxMappingPtr&, mnx::sequence::Event& mnxEvent
                 }
                 if (shape->calcIsSlur()) {
                     auto mnxSlur = createOneSlur(shape->endTermSeg->endPoint->entryNumber);
-                    mnxSlur.set_lineType(shape->calcIsDashed() ? mnx::LineType::Dashed : mnx::LineType::Solid);
+                    mnxSlur.set_lineType(shape->calcIsDashed() ? mnxdom::LineType::Dashed : mnxdom::LineType::Solid);
                     if (auto contourDir = shape->calcContourDirection(); contourDir != CurveContourDirection::Unspecified) {
-                        mnxSlur.set_side(contourDir == CurveContourDirection::Up ? mnx::SlurTieSide::Up : mnx::SlurTieSide::Down);
+                        mnxSlur.set_side(contourDir == CurveContourDirection::Up ? mnxdom::SlurTieSide::Up : mnxdom::SlurTieSide::Down);
                     }
                 }
             }
@@ -245,12 +247,12 @@ static void createSlurs(const MnxMusxMappingPtr&, mnx::sequence::Event& mnxEvent
     }
 }
 
-static mnx::sequence::EventMarkingBase createEventMarking(
-    mnx::sequence::EventMarkings mnxMarkings,
+static mnxdom::sequence::EventMarkingBase createEventMarking(
+    mnxdom::sequence::EventMarkings mnxMarkings,
     classify::StandardArticulation::Type mark,
     const details::ArticulationAssign::SelectedSymbolContext& symbolContext)
 {
-    const auto setPointing = [&](auto marking) -> mnx::sequence::EventMarkingBase {
+    const auto setPointing = [&](auto marking) -> mnxdom::sequence::EventMarkingBase {
         const auto& symbol = symbolContext.symbol;
         marking.set_or_clear_pointing(calcPointing(symbol.font, symbol.character, symbolContext.placement));
         return marking;
@@ -260,9 +262,9 @@ static mnx::sequence::EventMarkingBase createEventMarking(
     case classify::StandardArticulation::Type::Accent:
         return mnxMarkings.ensure_accent();
     case classify::StandardArticulation::Type::BowDirectionDown:
-        return mnxMarkings.ensure_bowDirection(mnx::MarkingUpDown::Down);
+        return mnxMarkings.ensure_bowDirection(mnxdom::MarkingUpDown::Down);
     case classify::StandardArticulation::Type::BowDirectionUp:
-        return mnxMarkings.ensure_bowDirection(mnx::MarkingUpDown::Up);
+        return mnxMarkings.ensure_bowDirection(mnxdom::MarkingUpDown::Up);
     case classify::StandardArticulation::Type::SoftAccent:
         return mnxMarkings.ensure_softAccent();
     case classify::StandardArticulation::Type::Spiccato:
@@ -283,10 +285,10 @@ static mnx::sequence::EventMarkingBase createEventMarking(
     throw std::logic_error("Encountered unknown standard articulation type " + std::to_string(int(mark)));
 }
 
-static void processArticulations(const MnxMusxMappingPtr& context, mnx::sequence::Event& mnxEvent, const EntryInfoPtr& musxEntryInfo)
+static void processArticulations(const MnxMusxMappingPtr& context, mnxdom::sequence::Event& mnxEvent, const EntryInfoPtr& musxEntryInfo)
 {
     const auto musxEntry = musxEntryInfo->getEntry();
-    auto mnxPartMeasure = mnxEvent.getEnclosingElement<mnx::part::Measure>();
+    auto mnxPartMeasure = mnxEvent.getEnclosingElement<mnxdom::part::Measure>();
     ASSERT_IF(!mnxPartMeasure) {
         context->logMessage(LogMsg() << "no part measure exists for " << mnxEvent.dump(4), MessageSeverity::Warning);
         return;
@@ -315,12 +317,12 @@ static void processArticulations(const MnxMusxMappingPtr& context, mnx::sequence
                 } else if (const auto* tremolo = classification.as<classify::Tremolo>()) {
                     auto mnxMarkings = mnxEvent.ensure_markings();
                     auto mnxMarking = mnxMarkings.ensure_tremolo(tremolo->marks);
-                    mnxMarking.set_or_clear_orient(enumConvert<mnx::Orientation>(symbolContext->placement));
+                    mnxMarking.set_or_clear_orient(enumConvert<mnxdom::Orientation>(symbolContext->placement));
                 } else if (const auto* articulation = classification.as<classify::StandardArticulation>()) {
                     for (auto mark : articulation->types) {
                         auto mnxMarkings = mnxEvent.ensure_markings();
                         auto mnxMarking = createEventMarking(mnxMarkings, mark, symbolContext.value());
-                        mnxMarking.set_or_clear_orient(enumConvert<mnx::Orientation>(symbolContext->placement));
+                        mnxMarking.set_or_clear_orient(enumConvert<mnxdom::Orientation>(symbolContext->placement));
                     }
                 }
             }
@@ -328,7 +330,7 @@ static void processArticulations(const MnxMusxMappingPtr& context, mnx::sequence
     }
 }
 
-mnx::sequence::Note createNormalNote(const MnxMusxMappingPtr& context, mnx::sequence::Event& mnxEvent, const NoteInfoPtr& musxNote)
+mnxdom::sequence::Note createNormalNote(const MnxMusxMappingPtr& context, mnxdom::sequence::Event& mnxEvent, const NoteInfoPtr& musxNote)
 {
     auto [noteName, octave, alteration, _] = musxNote.calcNotePropertiesConcert();
     for (const auto& it : context->current.ottavasApplicableInMeasure) {
@@ -340,19 +342,19 @@ mnx::sequence::Note createNormalNote(const MnxMusxMappingPtr& context, mnx::sequ
                 tiedFromNoteInfo = tiedFromNoteInfo.calcTieFrom();
             }
             if (!tiedFromNoteInfo || shape->calcAppliesTo(tiedFromNoteInfo.getEntryInfo())) {
-                octave += int(enumConvert<mnx::OttavaAmount>(shape->shapeType));
+                octave += int(enumConvert<mnxdom::OttavaAmount>(shape->shapeType));
             } else if (!musxNote.isSameNote(tiedFromNoteInfo)) {
                 context->logMessage(LogMsg() << "skipping ottava octave setting for tied-to note since the tied-from note is not under the ottava", MessageSeverity::Verbose);
             }
         }
     }
     auto mnxNote = mnxEvent.ensure_notes().append(
-        mnx::sequence::Pitch::make(enumConvert<mnx::NoteStep>(noteName), octave, alteration));
+        mnxdom::sequence::Pitch::make(enumConvert<mnxdom::NoteStep>(noteName), octave, alteration));
     if (musxNote->freezeAcci || musxNote->parenAcci) {
         auto acciDisp = mnxNote.ensure_accidentalDisplay(musxNote->showAcci);
         acciDisp.set_or_clear_force(musxNote->freezeAcci);
         if (musxNote->parenAcci) {
-            acciDisp.ensure_enclosure(mnx::AccidentalEnclosureSymbol::Parentheses);
+            acciDisp.ensure_enclosure(mnxdom::AccidentalEnclosureSymbol::Parentheses);
         }
     }
     const auto musxEntry = musxNote.getEntryInfo()->getEntry();
@@ -364,11 +366,11 @@ mnx::sequence::Note createNormalNote(const MnxMusxMappingPtr& context, mnx::sequ
     return mnxNote;
 }
 
-mnx::sequence::KitNote createKitNote(const MnxMusxMappingPtr& context, mnx::sequence::Event& mnxEvent, const MusxInstance<others::PercussionNoteInfo>& percNoteInfo,
+mnxdom::sequence::KitNote createKitNote(const MnxMusxMappingPtr& context, mnxdom::sequence::Event& mnxEvent, const MusxInstance<others::PercussionNoteInfo>& percNoteInfo,
     const MusxInstance<others::Staff>& musxStaff)
 {
     auto mnxNote = mnxEvent.ensure_kitNotes().append(calcPercussionKitId(percNoteInfo));
-    auto part = mnxNote.getEnclosingElement<mnx::Part>();
+    auto part = mnxNote.getEnclosingElement<mnxdom::Part>();
     MNX_ASSERT_IF(!part.has_value()) {
         throw std::logic_error("Note created without a part.");
     }
@@ -396,15 +398,15 @@ mnx::sequence::KitNote createKitNote(const MnxMusxMappingPtr& context, mnx::sequ
 }
 
 template <typename MnxNoteType>
-static void createNote(const MnxMusxMappingPtr& context, mnx::sequence::Event& mnxEvent, const NoteInfoPtr& musxNote,
+static void createNote(const MnxMusxMappingPtr& context, mnxdom::sequence::Event& mnxEvent, const NoteInfoPtr& musxNote,
     const MusxInstance<others::Staff>& musxStaff, const MusxInstance<others::PercussionNoteInfo>& percNoteInfo)
 {
-    static_assert(std::is_base_of_v<mnx::sequence::NoteBase, MnxNoteType>, "MnxNoteType must have base type NoteBase.");
+    static_assert(std::is_base_of_v<mnxdom::sequence::NoteBase, MnxNoteType>, "MnxNoteType must have base type NoteBase.");
 
     const auto musxEntry = musxNote.getEntryInfo()->getEntry();
 
     MnxNoteType mnxNote = [&]() {
-        if constexpr (std::is_same_v<MnxNoteType, mnx::sequence::Note>) {
+        if constexpr (std::is_same_v<MnxNoteType, mnxdom::sequence::Note>) {
             return createNormalNote(context, mnxEvent, musxNote);
         } else {
             MUSX_ASSERT_IF(!percNoteInfo) {
@@ -429,7 +431,7 @@ static void createNote(const MnxMusxMappingPtr& context, mnx::sequence::Event& m
     deferJumpTies(context, musxNote);
 }
 
-static void createNotes(const MnxMusxMappingPtr& context, mnx::sequence::Event& mnxEvent, const EntryInfoPtr& musxEntryInfo,
+static void createNotes(const MnxMusxMappingPtr& context, mnxdom::sequence::Event& mnxEvent, const EntryInfoPtr& musxEntryInfo,
     const MusxInstance<others::Staff>& musxStaff)
 {
     const auto musxEntry = musxEntryInfo->getEntry();
@@ -437,14 +439,14 @@ static void createNotes(const MnxMusxMappingPtr& context, mnx::sequence::Event& 
     for (size_t x = 0; x < musxEntry->notes.size(); x++) {
         const auto mnxNote = NoteInfoPtr(musxEntryInfo, x);
         if (const auto percNoteInfo = mnxNote.calcPercussionNoteInfo()) {
-            createNote<mnx::sequence::KitNote>(context, mnxEvent, mnxNote, musxStaff, percNoteInfo);
+            createNote<mnxdom::sequence::KitNote>(context, mnxEvent, mnxNote, musxStaff, percNoteInfo);
         } else {
-            createNote<mnx::sequence::Note>(context, mnxEvent, mnxNote, musxStaff, nullptr);
+            createNote<mnxdom::sequence::Note>(context, mnxEvent, mnxNote, musxStaff, nullptr);
         }
     }
 }
 
-static void createRest([[maybe_unused]] const MnxMusxMappingPtr& context, mnx::sequence::Event& mnxEvent, const EntryInfoPtr& musxEntryInfo,
+static void createRest([[maybe_unused]] const MnxMusxMappingPtr& context, mnxdom::sequence::Event& mnxEvent, const EntryInfoPtr& musxEntryInfo,
     const MusxInstance<others::Staff>& musxStaff)
 {
     const auto musxEntry = musxEntryInfo->getEntry();
@@ -454,17 +456,17 @@ static void createRest([[maybe_unused]] const MnxMusxMappingPtr& context, mnx::s
     if (!musxEntry->isHidden && !musxEntry->floatRest && !musxEntry->notes.empty()) {
         auto musxRest = NoteInfoPtr(musxEntryInfo, 0);
         auto staffPosition = std::get<3>(musxRest.calcNotePropertiesInView());
-        if (mnxEvent.duration().base() == mnx::NoteValueBase::Whole) {
+        if (mnxEvent.duration().base() == mnxdom::NoteValueBase::Whole) {
             staffPosition += 2; // compensate for discrepancy in Finale vs. MNX whole rest staff positions.
         }
         mnxRest.set_staffPosition(mnxStaffPosition(musxStaff, staffPosition));
     }
 }
 
-static void createFullMeasureRest(const MnxMusxMappingPtr& context, mnx::sequence::SequenceContent content,
+static void createFullMeasureRest(const MnxMusxMappingPtr& context, mnxdom::sequence::SequenceContent content,
     const EntryInfoPtr& musxEntryInfo)
 {
-    auto sequence = content.getEnclosingElement<mnx::Sequence>();
+    auto sequence = content.getEnclosingElement<mnxdom::Sequence>();
     if (!sequence) {
         context->logMessage(LogMsg() << " full measure rest could not be assigned to a top-level sequence.", MessageSeverity::Warning);
         return;
@@ -501,7 +503,7 @@ static void createFullMeasureRest(const MnxMusxMappingPtr& context, mnx::sequenc
     content.clear();
 }
 
-static void createLyrics(const MnxMusxMappingPtr& context, mnx::sequence::Event& mnxEvent, const EntryInfoPtr& musxEntryInfo)
+static void createLyrics(const MnxMusxMappingPtr& context, mnxdom::sequence::Event& mnxEvent, const EntryInfoPtr& musxEntryInfo)
 {
     const auto musxEntry = musxEntryInfo->getEntry();
 
@@ -532,7 +534,7 @@ static void createLyrics(const MnxMusxMappingPtr& context, mnx::sequence::Event&
     createLyricsType(musxEntry->getDocument()->getDetails()->getArray<details::LyricAssignSection>(SCORE_PARTID, musxEntry->getEntryNumber()));
 }
 
-static std::optional<mnx::sequence::Event> createEvent(const MnxMusxMappingPtr& context, mnx::sequence::SequenceContent content,
+static std::optional<mnxdom::sequence::Event> createEvent(const MnxMusxMappingPtr& context, mnxdom::sequence::SequenceContent content,
     EntryInfoPtr musxEntryInfo, bool effectiveHidden, bool hasVoice1Voice2,
     const MusxInstance<details::TupletDef>& tupletDef, bool forTremolo)
 {
@@ -575,10 +577,10 @@ static std::optional<mnx::sequence::Event> createEvent(const MnxMusxMappingPtr& 
     const auto [freezeStem, upStem] = musxEntryInfo.calcEntryStemSettings();
     if (musxEntry->isNote && musxEntry->hasStem()) {
         if (freezeStem) {
-            mnxEvent.set_stemDirection(upStem ? mnx::StemDirection::Up : mnx::StemDirection::Down);
+            mnxEvent.set_stemDirection(upStem ? mnxdom::StemDirection::Up : mnxdom::StemDirection::Down);
         } else if (hasVoice1Voice2) {
             // force all stems in v1v2 contexts due to voices controlling stem direction otherwise.
-            mnxEvent.set_stemDirection(musxEntryInfo.calcUpStem() ? mnx::StemDirection::Up : mnx::StemDirection::Down);
+            mnxEvent.set_stemDirection(musxEntryInfo.calcUpStem() ? mnxdom::StemDirection::Up : mnxdom::StemDirection::Down);
         }
     }
 
@@ -592,7 +594,7 @@ static std::optional<mnx::sequence::Event> createEvent(const MnxMusxMappingPtr& 
 
 /// @brief processes as many entries as it can and returns the next entry to process up to the caller
 static EntryInfoPtr::InterpretedIterator addEntryToContent(const MnxMusxMappingPtr& context,
-    mnx::sequence::SequenceContent content, const EntryInfoPtr::InterpretedIterator& firstEntryInfo,
+    mnxdom::sequence::SequenceContent content, const EntryInfoPtr::InterpretedIterator& firstEntryInfo,
     musx::util::Fraction& elapsedInSequence, bool hasVoice1Voice2,
     bool inGrace, const std::optional<size_t>& tupletIndex = std::nullopt, bool inTremolo = false)
 {
@@ -724,7 +726,7 @@ static EntryInfoPtr::InterpretedIterator addEntryToContent(const MnxMusxMappingP
 }
 
 void createSequences(const MnxMusxMappingPtr& context,
-    mnx::part::Measure& mnxMeasure,
+    mnxdom::part::Measure& mnxMeasure,
     std::optional<int> mnxStaffNumber,
     const MusxInstance<others::Measure>& musxMeasure)
 {
@@ -768,19 +770,19 @@ void finalizeJumpTies(const MnxMusxMappingPtr& context)
     }
 
     std::unordered_set<std::string> clearedLvTies;
-    std::unordered_map<std::string, std::optional<mnx::SlurTieSide>> consensusSides;
+    std::unordered_map<std::string, std::optional<mnxdom::SlurTieSide>> consensusSides;
     for (const auto& deferred : context->deferredJumpTies) {
         const auto noteIt = context->noteJsonById.find(deferred.startNoteId);
         if (noteIt == context->noteJsonById.end()) {
             continue;
         }
 
-        mnx::sequence::NoteBase startNote(context->mnxDocument->root(), noteIt->second);
-        const auto consensusSide = [&]() -> std::optional<mnx::SlurTieSide> {
+        mnxdom::sequence::NoteBase startNote(context->mnxDocument->root(), noteIt->second);
+        const auto consensusSide = [&]() -> std::optional<mnxdom::SlurTieSide> {
             if (const auto cached = consensusSides.find(deferred.startNoteId); cached != consensusSides.end()) {
                 return cached->second;
             }
-            std::optional<mnx::SlurTieSide> side;
+            std::optional<mnxdom::SlurTieSide> side;
             bool hasNonLv = false;
             if (auto tiesOpt = startNote.ties()) {
                 auto ties = tiesOpt.value();
@@ -839,7 +841,7 @@ void finalizeJumpTies(const MnxMusxMappingPtr& context)
 
         auto mnxTie = mnxTies.append();
         mnxTie.set_target(deferred.endNoteId);
-        mnxTie.set_targetType(mnx::TieTargetType::CrossJump);
+        mnxTie.set_targetType(mnxdom::TieTargetType::CrossJump);
         if (deferred.side) {
             mnxTie.set_side(deferred.side.value());
         } else if (consensusSide) {
@@ -848,5 +850,7 @@ void finalizeJumpTies(const MnxMusxMappingPtr& context)
     }
 }
 
-} // namespace mnxexp
+} // namespace detail
+} // namespace mnx
+} // namespace formats
 } // namespace denigma

--- a/src/formats/mnx/mnx_smartshapes.cpp
+++ b/src/formats/mnx/mnx_smartshapes.cpp
@@ -25,14 +25,16 @@
 #include "mnx_markings.h"
 
 namespace denigma {
-namespace mnxexp {
+namespace formats {
+namespace mnx {
+namespace detail {
 
 namespace {
-void appendHairpin(const MnxMusxMappingPtr&, mnx::part::Measure& mnxMeasure, std::optional<int> mnxStaffNumber,
-    const MusxInstance<others::SmartShape>& shape, mnx::DynamicWedgeType wedgeType)
+void appendHairpin(const MnxMusxMappingPtr&, mnxdom::part::Measure& mnxMeasure, std::optional<int> mnxStaffNumber,
+    const MusxInstance<others::SmartShape>& shape, mnxdom::DynamicWedgeType wedgeType)
 {
     const auto startPos = mnxFractionFromFraction(shape->startTermSeg->endPoint->calcGlobalPosition());
-    const auto endPos = mnx::MeasureRhythmicPosition::make(
+    const auto endPos = mnxdom::MeasureRhythmicPosition::make(
         calcGlobalMeasureId(shape->endTermSeg->endPoint->measId),
         mnxFractionFromFraction(shape->endTermSeg->endPoint->calcGlobalPosition()));
     auto mnxDynamic = mnxMeasure.ensure_dynamics().appendGradual(wedgeType, startPos, endPos);
@@ -47,7 +49,7 @@ void appendHairpin(const MnxMusxMappingPtr&, mnx::part::Measure& mnxMeasure, std
 } // namespace
 
 void processSmartShapes(const MnxMusxMappingPtr& context, const MusxInstance<others::Measure>& musxMeasure,
-    mnx::part::Measure& mnxMeasure, std::optional<int> mnxStaffNumber)
+    mnxdom::part::Measure& mnxMeasure, std::optional<int> mnxStaffNumber)
 {
     if (musxMeasure->hasSmartShape) {
         const auto assigns = context->document->getOthers()->getArray<others::SmartShapeMeasureAssign>(musxMeasure->getRequestedPartId(), musxMeasure->getCmper());
@@ -68,10 +70,10 @@ void processSmartShapes(const MnxMusxMappingPtr& context, const MusxInstance<oth
             using ST = musx::dom::others::SmartShape::ShapeType;
             switch (shape->shapeType) {
             case ST::Crescendo:
-                appendHairpin(context, mnxMeasure, mnxStaffNumber, shape, mnx::DynamicWedgeType::Increasing);
+                appendHairpin(context, mnxMeasure, mnxStaffNumber, shape, mnxdom::DynamicWedgeType::Increasing);
                 break;
             case ST::Decrescendo:
-                appendHairpin(context, mnxMeasure, mnxStaffNumber, shape, mnx::DynamicWedgeType::Decreasing);
+                appendHairpin(context, mnxMeasure, mnxStaffNumber, shape, mnxdom::DynamicWedgeType::Decreasing);
                 break;
             default:
                 if (const auto nonArpeggio = musx::util::calcNonArpeggioSpanForSmartShape(shape)) {
@@ -84,7 +86,7 @@ void processSmartShapes(const MnxMusxMappingPtr& context, const MusxInstance<oth
 }
 
 void createOttavas(const MnxMusxMappingPtr& context, const MusxInstance<others::Measure>& musxMeasure,
-    mnx::part::Measure& mnxMeasure, std::optional<int> mnxStaffNumber)
+    mnxdom::part::Measure& mnxMeasure, std::optional<int> mnxStaffNumber)
 {
     const StaffCmper staffCmper = context->current.staff;
     context->current.ottavasApplicableInMeasure.clear();
@@ -104,9 +106,9 @@ void createOttavas(const MnxMusxMappingPtr& context, const MusxInstance<others::
                     context->current.ottavasApplicableInMeasure.emplace(shape->getCmper(), shape);
                     if (!asgn->centerShapeNum && shape->startTermSeg->endPoint->measId == musxMeasure->getCmper()) {
                         auto mnxOttava = mnxMeasure.ensure_ottavas().append(
-                            enumConvert<mnx::OttavaAmount>(shape->shapeType),
+                            enumConvert<mnxdom::OttavaAmount>(shape->shapeType),
                             mnxFractionFromSmartShapeEndPoint(shape->startTermSeg->endPoint),
-                            mnx::MeasureRhythmicPosition::make(calcGlobalMeasureId(shape->endTermSeg->endPoint->measId),
+                            mnxdom::MeasureRhythmicPosition::make(calcGlobalMeasureId(shape->endTermSeg->endPoint->measId),
                                                                mnxFractionFromSmartShapeEndPoint(shape->endTermSeg->endPoint)));
                         mnxOttava.end().position().set_graceIndex(0);   // guarantees inclusion of any grace notes at the end of the ottava
                         if (mnxStaffNumber) {
@@ -120,5 +122,7 @@ void createOttavas(const MnxMusxMappingPtr& context, const MusxInstance<others::
     }
 }
 
-} // namespace mnxexp
+} // namespace detail
+} // namespace mnx
+} // namespace formats
 } // namespace denigma

--- a/src/formats/mnx/mnx_smartshapes.h
+++ b/src/formats/mnx/mnx_smartshapes.h
@@ -31,15 +31,19 @@ using namespace musx::dom;
 using namespace musx::util;
 
 namespace denigma {
-namespace mnxexp {
+namespace formats {
+namespace mnx {
+namespace detail {
 
 // all smart shapes except ottavas
 void processSmartShapes(const MnxMusxMappingPtr& context, const MusxInstance<others::Measure>& musxMeasure,
-    mnx::part::Measure& mnxMeasure, std::optional<int> mnxStaffNumber);
+    mnxdom::part::Measure& mnxMeasure, std::optional<int> mnxStaffNumber);
 
 // createOttavas is separate because it needs to run before sequence creation
 void createOttavas(const MnxMusxMappingPtr& context, const MusxInstance<others::Measure>& musxMeasure,
-    mnx::part::Measure& mnxMeasure, std::optional<int> mnxStaffNumber);
+    mnxdom::part::Measure& mnxMeasure, std::optional<int> mnxStaffNumber);
 
-} // namespace mnxexp
+} // namespace detail
+} // namespace mnx
+} // namespace formats
 } // namespace denigma

--- a/src/formats/mss/mss.cpp
+++ b/src/formats/mss/mss.cpp
@@ -46,7 +46,9 @@
 #include "utils/textmetrics.h"
 
 namespace denigma {
+namespace formats {
 namespace mss {
+namespace detail {
 
 using namespace ::musx::dom;
 using namespace ::musx::factory;
@@ -1191,5 +1193,7 @@ void convert(const std::filesystem::path& outputPath, const CommandInputData& in
     }
 }
 
+} // namespace detail
 } // namespace mss
+} // namespace formats
 } // namespace denigma

--- a/src/formats/mss/mss.h
+++ b/src/formats/mss/mss.h
@@ -31,7 +31,9 @@
  //placeholder function
 
 namespace denigma {
+namespace formats {
 namespace mss {
+namespace detail {
 
 void convert(std::ostream& output, const CommandInputData& inputData, const DenigmaContext& denigmaContext);
 void convert(const CommandInputData& inputData,
@@ -39,5 +41,7 @@ void convert(const CommandInputData& inputData,
              const MultiOutputCallback& outputCallback);
 void convert(const std::filesystem::path& file, const CommandInputData& inputData, const DenigmaContext& denigmaContext);
 
+} // namespace detail
 } // namespace mss
+} // namespace formats
 } // namespace denigma

--- a/src/formats/mss/mss_converter.cpp
+++ b/src/formats/mss/mss_converter.cpp
@@ -27,7 +27,9 @@
 #include "mss.h"
 #include "utils/stringutils.h"
 
-namespace denigma::formats::mss {
+namespace denigma {
+namespace formats {
+namespace mss {
 
 namespace {
 
@@ -68,7 +70,7 @@ ConversionResult EnigmaXmlToMssXmlConverter::convert(std::span<const std::byte> 
     context.conversionResult = &result;
     MusxLoggerScope musxLogger(makeMusxLogCallback(context));
 
-    denigma::mss::convert(output, CommandInputData{ std::move(buffer), std::nullopt, {} }, context);
+    formats::mss::detail::convert(output, CommandInputData{ std::move(buffer), std::nullopt, {} }, context);
     return result;
 }
 
@@ -89,7 +91,7 @@ ConversionResult MusxToMssXmlConverter::convert(const IRandomAccessReader& input
     context.conversionResult = &result;
     MusxLoggerScope musxLogger(makeMusxLogCallback(context));
 
-    denigma::mss::convert(output, enigmaxml::extractMusxInputData(input, context), context);
+    formats::mss::detail::convert(output, formats::enigmaxml::detail::extractMusxInputData(input, context), context);
     return result;
 }
 
@@ -111,7 +113,7 @@ ConversionResult EnigmaXmlToMssXmlMultiOutputConverter::convert(std::span<const 
     context.conversionResult = &result;
     MusxLoggerScope musxLogger(makeMusxLogCallback(context));
 
-    denigma::mss::convert(CommandInputData{ std::move(buffer), std::nullopt, {} }, context, outputCallback);
+    formats::mss::detail::convert(CommandInputData{ std::move(buffer), std::nullopt, {} }, context, outputCallback);
     return result;
 }
 
@@ -132,7 +134,7 @@ ConversionResult MusxToMssXmlMultiOutputConverter::convert(const IRandomAccessRe
     context.conversionResult = &result;
     MusxLoggerScope musxLogger(makeMusxLogCallback(context));
 
-    denigma::mss::convert(enigmaxml::extractMusxInputData(input, context), context, outputCallback);
+    formats::mss::detail::convert(formats::enigmaxml::detail::extractMusxInputData(input, context), context, outputCallback);
     return result;
 }
 
@@ -151,4 +153,6 @@ void registerConverters(ConverterRegistry& registry)
     registry.add(std::make_unique<MusxToMssXmlMultiOutputConverter>());
 }
 
-} // namespace denigma::formats::mss
+} // namespace mss
+} // namespace formats
+} // namespace denigma

--- a/src/formats/svg/svg.cpp
+++ b/src/formats/svg/svg.cpp
@@ -35,7 +35,9 @@
 #include "utils/textmetrics.h"
 
 namespace denigma {
-namespace svgexp {
+namespace formats {
+namespace svg {
+namespace detail {
 
 using namespace musx::dom;
 using namespace musx::factory;
@@ -224,5 +226,7 @@ void convert(const std::filesystem::path& outputPath, const CommandInputData& in
     }
 }
 
-} // namespace svgexp
+} // namespace detail
+} // namespace svg
+} // namespace formats
 } // namespace denigma

--- a/src/formats/svg/svg.h
+++ b/src/formats/svg/svg.h
@@ -27,12 +27,16 @@
 #include "core/denigma.h"
 
 namespace denigma {
-namespace svgexp {
+namespace formats {
+namespace svg {
+namespace detail {
 
 void convert(const CommandInputData& inputData,
              const DenigmaContext& denigmaContext,
              const MultiOutputCallback& outputCallback);
 void convert(const std::filesystem::path& outputPath, const CommandInputData& inputData, const DenigmaContext& denigmaContext);
 
-} // namespace svgexp
+} // namespace detail
+} // namespace svg
+} // namespace formats
 } // namespace denigma

--- a/src/formats/svg/svg_converter.cpp
+++ b/src/formats/svg/svg_converter.cpp
@@ -27,7 +27,9 @@
 #include "svg.h"
 #include "utils/stringutils.h"
 
-namespace denigma::formats::svg {
+namespace denigma {
+namespace formats {
+namespace svg {
 
 namespace {
 
@@ -88,7 +90,7 @@ ConversionResult EnigmaXmlToSvgConverter::convert(std::span<const std::byte> inp
     applySvgOptions(context, options);
     MusxLoggerScope musxLogger(makeMusxLogCallback(context));
 
-    svgexp::convert(CommandInputData{ std::move(buffer), std::nullopt, {} }, context, outputCallback);
+    formats::svg::detail::convert(CommandInputData{ std::move(buffer), std::nullopt, {} }, context, outputCallback);
     return result;
 }
 
@@ -113,7 +115,7 @@ ConversionResult MusxToSvgConverter::convert(const IRandomAccessReader& input,
     applySvgOptions(context, options);
     MusxLoggerScope musxLogger(makeMusxLogCallback(context));
 
-    svgexp::convert(enigmaxml::extractMusxInputData(input, context), context, outputCallback);
+    formats::svg::detail::convert(formats::enigmaxml::detail::extractMusxInputData(input, context), context, outputCallback);
     return result;
 }
 
@@ -130,4 +132,6 @@ void registerConverters(ConverterRegistry& registry)
     registry.add(std::make_unique<MusxToSvgConverter>());
 }
 
-} // namespace denigma::formats::svg
+} // namespace svg
+} // namespace formats
+} // namespace denigma

--- a/src/massage/massage.cpp
+++ b/src/massage/massage.cpp
@@ -40,7 +40,7 @@ static CommandInputData nullFunc(const std::filesystem::path&, const DenigmaCont
 
 static CommandInputData readMusicXml(const std::filesystem::path& inputPath, const DenigmaContext& denigmaContext)
 {
-    return enigmaxml::readEnigmaXmlInputData(inputPath, denigmaContext);
+    return formats::enigmaxml::detail::readEnigmaXmlInputData(inputPath, denigmaContext);
 }
 
 // Input format processors

--- a/src/massage/musicxml.cpp
+++ b/src/massage/musicxml.cpp
@@ -691,9 +691,9 @@ static std::shared_ptr<MassageMusicXmlContext> createContext(const std::filesyst
             Buffer retval;
             const auto& path = finaleFilePath.value();
             if (utils::pathExtensionEquals(path, MUSX_EXTENSION)) {
-                return enigmaxml::extractMusxInputData(path, denigmaContext).primaryBuffer;
+                return formats::enigmaxml::detail::extractMusxInputData(path, denigmaContext).primaryBuffer;
             } else if (utils::pathExtensionEquals(path, ENIGMAXML_EXTENSION)) {
-                return enigmaxml::readEnigmaXmlInputData(path, denigmaContext).primaryBuffer;
+                return formats::enigmaxml::detail::readEnigmaXmlInputData(path, denigmaContext).primaryBuffer;
             }
             assert(false); // bug in findFinaleFile if here
             return {};

--- a/tests/mnx/test_formatted_text.cpp
+++ b/tests/mnx/test_formatted_text.cpp
@@ -28,7 +28,8 @@
 #include "formats/mnx/mnx_formatted_text.h"
 #include "musx/musx.h"
 
-using namespace denigma::mnxexp;
+namespace mnxdom = ::mnx;
+using namespace denigma::formats::mnx::detail;
 using namespace musx::dom;
 
 namespace {
@@ -88,7 +89,7 @@ TEST(MnxFormattedText, ConvertsStyledText)
 
     const auto formatted = makeFormattedText(ctx.parsingContext);
 
-    EXPECT_EQ(mnx::json::parse(formatted.dump()), mnx::json::parse(R"json([
+    EXPECT_EQ(mnxdom::json::parse(formatted.dump()), mnxdom::json::parse(R"json([
         {
             "text": "Bold Italic",
             "style": {
@@ -109,7 +110,7 @@ TEST(MnxFormattedText, ReplacesExistingContent)
 
     setFormattedText(formatted, secondCtx.parsingContext);
 
-    EXPECT_EQ(mnx::json::parse(formatted.dump()), mnx::json::parse(R"json([
+    EXPECT_EQ(mnxdom::json::parse(formatted.dump()), mnxdom::json::parse(R"json([
         {
             "text": "Second",
             "style": {
@@ -126,7 +127,7 @@ TEST(MnxFormattedText, ConvertsSmuflGlyphs)
 
     const auto formatted = makeFormattedText(ctx.parsingContext);
 
-    EXPECT_EQ(mnx::json::parse(formatted.dump()), mnx::json::parse(R"json([
+    EXPECT_EQ(mnxdom::json::parse(formatted.dump()), mnxdom::json::parse(R"json([
         {
             "type": "smufl",
             "glyphs": ["dynamicPiano"],
@@ -144,7 +145,7 @@ TEST(MnxFormattedText, PreservesMixedSmuflTextByDefault)
 
     const auto formatted = makeFormattedText(ctx.parsingContext);
 
-    EXPECT_EQ(mnx::json::parse(formatted.dump()), mnx::json::parse(R"json([
+    EXPECT_EQ(mnxdom::json::parse(formatted.dump()), mnxdom::json::parse(R"json([
         {
             "text": "p f",
             "style": {
@@ -161,7 +162,7 @@ TEST(MnxFormattedText, OmitsLegacyFontStyleFromSmuflGlyphs)
 
     const auto formatted = makeFormattedText(ctx.parsingContext);
 
-    EXPECT_EQ(mnx::json::parse(formatted.dump()), mnx::json::parse(R"json([
+    EXPECT_EQ(mnxdom::json::parse(formatted.dump()), mnxdom::json::parse(R"json([
         {
             "type": "smufl",
             "glyphs": ["dynamicPiano", "dynamicForte"]
@@ -177,7 +178,7 @@ TEST(MnxFormattedText, SplitsSmuflGlyphsFromMixedTextWhenRequested)
 
     const auto formatted = makeFormattedText(ctx.parsingContext, options);
 
-    EXPECT_EQ(mnx::json::parse(formatted.dump()), mnx::json::parse(R"json([
+    EXPECT_EQ(mnxdom::json::parse(formatted.dump()), mnxdom::json::parse(R"json([
         {
             "type": "smufl",
             "glyphs": ["dynamicPiano"]
@@ -211,7 +212,7 @@ TEST(MnxFormattedText, CallsOptionalChunkCallback)
 
     EXPECT_EQ(chunks, (std::vector<std::string>{ "Text ", "pf" }));
     EXPECT_EQ(glyphs, (std::vector<std::vector<std::string>>{ {}, { "dynamicPiano", "dynamicForte" } }));
-    EXPECT_EQ(mnx::json::parse(formatted.dump()), mnx::json::parse(R"json([
+    EXPECT_EQ(mnxdom::json::parse(formatted.dump()), mnxdom::json::parse(R"json([
         {
             "text": "Text ",
             "style": {
@@ -242,7 +243,7 @@ TEST(MnxFormattedText, ChunkCallbackPreservesTextPolicy)
 
     EXPECT_EQ(chunks, (std::vector<std::string>{ "pf" }));
     EXPECT_EQ(glyphs, (std::vector<std::vector<std::string>>{ {} }));
-    EXPECT_EQ(mnx::json::parse(formatted.dump()), mnx::json::parse(R"json([
+    EXPECT_EQ(mnxdom::json::parse(formatted.dump()), mnxdom::json::parse(R"json([
         {
             "text": "pf",
             "style": {

--- a/tests/mnx/test_global.cpp
+++ b/tests/mnx/test_global.cpp
@@ -28,6 +28,8 @@
 #include "core/denigma.h"
 #include "core/musx_reader.h"
 #include "mnxdom.h"
+
+namespace mnxdom = ::mnx;
 #include "test_utils.h"
 #include "musx/musx.h"
 #include "formats/mnx/mnx.h"
@@ -45,7 +47,7 @@ TEST(MnxGlobal, Tempos)
         EXPECT_EQ(denigmaTestMain(args.argc(), args.argv()), 0) << "export to mnx: " << pathString(inputPath);
     });
 
-    auto doc = mnx::Document::create(inputPath.parent_path() / "tempo_text_shape.mnx");
+    auto doc = mnxdom::Document::create(inputPath.parent_path() / "tempo_text_shape.mnx");
     auto measures = doc.global().measures();
     ASSERT_GE(measures.size(), 1) << "should be at least one measure";
     auto tempos = measures[0].tempos();
@@ -97,7 +99,7 @@ TEST(MnxGlobal, TempoToolChanges)
     auto musxDoc = musx::factory::DocumentFactory::create<MusxReader>(xmlBuf);
     ASSERT_TRUE(musxDoc);
 
-    auto mnxDoc = mnx::Document::create(inputPath.parent_path() / "tempo_changes.mnx");
+    auto mnxDoc = mnxdom::Document::create(inputPath.parent_path() / "tempo_changes.mnx");
     auto measures = mnxDoc.global().measures();
     ASSERT_GE(measures.size(), 4) << "should be at least 4 measures";
 
@@ -112,7 +114,7 @@ TEST(MnxGlobal, TempoToolChanges)
             auto musxDura = musx::util::Fraction::fromEdu(musxTempoChanges[y]->eduPosition);
             musx::util::Fraction mnxDura;
             if (const auto location = mnxTempoChanges->at(y).location()) {
-                mnxDura = mnxexp::fractionFromMnxFraction(location->fraction());
+                mnxDura = formats::mnx::detail::fractionFromMnxFraction(location->fraction());
             }
             EXPECT_EQ(musxDura, mnxDura) << "measure positions are not the same";
         }
@@ -129,12 +131,12 @@ TEST(MnxGlobal, CompositeTime)
         EXPECT_EQ(denigmaTestMain(args.argc(), args.argv()), 0) << "export to mnx: " << pathString(inputPath);
     });
 
-    auto doc = mnx::Document::create(inputPath.parent_path() / "timesigs_composite.mnx");
+    auto doc = mnxdom::Document::create(inputPath.parent_path() / "timesigs_composite.mnx");
     auto measures = doc.global().measures();
     ASSERT_GE(measures.size(), 1) << "should be at least one measure";
 
     auto time = measures[0].time();
     ASSERT_TRUE(time);
     EXPECT_EQ(time.value().count(), 133);
-    EXPECT_EQ(time.value().unit(), mnx::TimeSignatureUnit::Value32nd);
+    EXPECT_EQ(time.value().unit(), mnxdom::TimeSignatureUnit::Value32nd);
 }

--- a/tests/mnx/test_sequences.cpp
+++ b/tests/mnx/test_sequences.cpp
@@ -33,14 +33,14 @@ using namespace denigma;
 
 TEST(MnxSequences, CalcPointing)
 {
-    using mnxexp::calcPointing;
+    using formats::mnx::detail::calcPointing;
 
-    EXPECT_EQ(calcPointing("articMarcatoAbove", VerticalPlacement::Above), mnx::MarkingUpDownAuto::Auto);
-    EXPECT_EQ(calcPointing("articMarcatoBelow", VerticalPlacement::Above), mnx::MarkingUpDownAuto::Down);
-    EXPECT_EQ(calcPointing("articMarcatoAbove", VerticalPlacement::Below), mnx::MarkingUpDownAuto::Up);
-    EXPECT_EQ(calcPointing("articMarcatoStaccatoBelowLegacy", VerticalPlacement::Above), mnx::MarkingUpDownAuto::Down);
-    EXPECT_EQ(calcPointing("fermataBelow", VerticalPlacement::Above), mnx::MarkingUpDownAuto::Down);
-    EXPECT_EQ(calcPointing("curlewSign", VerticalPlacement::Above), mnx::MarkingUpDownAuto::Auto);
+    EXPECT_EQ(calcPointing("articMarcatoAbove", VerticalPlacement::Above), mnxdom::MarkingUpDownAuto::Auto);
+    EXPECT_EQ(calcPointing("articMarcatoBelow", VerticalPlacement::Above), mnxdom::MarkingUpDownAuto::Down);
+    EXPECT_EQ(calcPointing("articMarcatoAbove", VerticalPlacement::Below), mnxdom::MarkingUpDownAuto::Up);
+    EXPECT_EQ(calcPointing("articMarcatoStaccatoBelowLegacy", VerticalPlacement::Above), mnxdom::MarkingUpDownAuto::Down);
+    EXPECT_EQ(calcPointing("fermataBelow", VerticalPlacement::Above), mnxdom::MarkingUpDownAuto::Down);
+    EXPECT_EQ(calcPointing("curlewSign", VerticalPlacement::Above), mnxdom::MarkingUpDownAuto::Auto);
 }
 
 TEST(MnxSequences, Voice2TripletAtEnd)
@@ -55,7 +55,7 @@ TEST(MnxSequences, Voice2TripletAtEnd)
         EXPECT_EQ(denigmaTestMain(args.argc(), args.argv()), 0) << "export to mnx: " << pathString(inputPath);
     });
 
-    auto doc = mnx::Document::create(inputPath.parent_path() / "v2triplet_at_end.mnx");
+    auto doc = mnxdom::Document::create(inputPath.parent_path() / "v2triplet_at_end.mnx");
 }
 
 TEST(MnxSequences, Voice2TupletIncomplete)
@@ -70,7 +70,7 @@ TEST(MnxSequences, Voice2TupletIncomplete)
         EXPECT_EQ(denigmaTestMain(args.argc(), args.argv()), 0) << "export to mnx: " << pathString(inputPath);
     });
 
-    auto doc = mnx::Document::create(inputPath.parent_path() / "v2tuplet_incomplete.mnx");
+    auto doc = mnxdom::Document::create(inputPath.parent_path() / "v2tuplet_incomplete.mnx");
 }
 
 TEST(MnxSequences, NestedTuplets)
@@ -85,7 +85,7 @@ TEST(MnxSequences, NestedTuplets)
         EXPECT_EQ(denigmaTestMain(args.argc(), args.argv()), 0) << "export to mnx: " << pathString(inputPath);
     });
 
-    auto doc = mnx::Document::create(inputPath.parent_path() / "tuplets_nested.mnx");
+    auto doc = mnxdom::Document::create(inputPath.parent_path() / "tuplets_nested.mnx");
 }
 
 TEST(MnxSequences, NestedTrailingSingletonTuplet)
@@ -100,5 +100,5 @@ TEST(MnxSequences, NestedTrailingSingletonTuplet)
         EXPECT_EQ(denigmaTestMain(args.argc(), args.argv()), 0) << "export to mnx: " << pathString(inputPath);
     });
 
-    auto doc = mnx::Document::create(inputPath.parent_path() / "tuplet-nested-singleton.mnx");
+    auto doc = mnxdom::Document::create(inputPath.parent_path() / "tuplet-nested-singleton.mnx");
 }


### PR DESCRIPTION
All format implementations now live in `denigma::formats::<format>::detail` namespaces.