### PR TITLE
docs: add issue forms and expand MusicXML roadmap

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,114 @@
+name: Bug report
+description: Report behavior that is incorrect, unexpected, or crashes denigma
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve denigma. Please reduce the problem to the smallest reproducible example you can share. If this is a request for MusicXML support that denigma does not yet implement, use the [MusicXML feature gap form](https://github.com/rpatters1/denigma/issues/new?template=musicxml-gap.yml) instead.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Bug summary
+      description: Briefly describe what went wrong and its impact.
+      placeholder: What operation failed, and how does that affect the resulting score or workflow?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Select the area most directly involved.
+      options:
+        - Command-line interface
+        - Enigma XML
+        - MusicXML
+        - MNX
+        - MSS
+        - SVG
+        - Classification or massage
+        - Build or installation
+        - Other or unknown
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Version and environment
+      description: Give the denigma release or commit, operating system and architecture, and relevant source or destination application versions. If this worked before, identify the last known working version.
+      placeholder: |
+        - denigma version or commit:
+        - Operating system and architecture:
+        - Source application and version:
+        - Destination application and version:
+        - Last known working denigma version, if any:
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: List the exact command or workflow and identify the relevant measure, staff, or score item.
+      placeholder: |
+        1. Run `denigma ...`
+        2. Open or inspect ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-actual
+    attributes:
+      label: Expected and actual behavior
+      description: Explain what you expected and what happened instead. Include enough detail to define when the bug is fixed.
+      placeholder: |
+        Expected:
+
+        Actual:
+    validations:
+      required: true
+
+  - type: upload
+    id: sample-files
+    attributes:
+      label: Minimal sample files
+      description: Upload the smallest input and output files that reproduce the bug. Append `.zip` to MUSX filenames without recompressing them; ZIP other unsupported formats.
+    validations:
+      required: false
+      accept: ".zip,.gz,.tar.gz,.json,.log,.txt,.csv,.pdf,.png,.jpg,.jpeg,.gif,.svg,.webp"
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics and additional context
+      description: Paste relevant console output in a fenced code block. Add screenshots, validation errors, workarounds, or other context that helps isolate the cause. Remove secrets and personal information.
+      placeholder: |
+        ```text
+        Relevant output
+        ```
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: prior-search
+    attributes:
+      label: Prior search
+      description: Confirm that this bug is not already tracked in [open or closed GitHub issues](https://github.com/rpatters1/denigma/issues?q=is%3Aissue).
+      options:
+        - label: I searched both open and closed issues for this bug.
+          required: true
+
+  - type: checkboxes
+    id: sharing
+    attributes:
+      label: Permission to use attachments for testing
+      description: Public issue attachments can be viewed and downloaded by anyone. Test fixtures committed to denigma are distributed under the repository's [MIT License](https://github.com/rpatters1/denigma/blob/main/LICENSE).
+      options:
+        - label: If I attached example files, I own them or have authority to grant permission, and they contain no private or sensitive information.
+          required: true
+        - label: If I attached example files, I grant the denigma project permission to retain, copy, modify, minimize, and redistribute them in its public repository, including as automated test fixtures under the MIT License.
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for helping improve denigma. Please reduce the problem to the smallest reproducible example you can share. If this is a request for MusicXML support that denigma does not yet implement, use the [MusicXML feature gap form](https://github.com/rpatters1/denigma/issues/new?template=musicxml-gap.yml) instead.
+        Thank you for helping improve denigma. Please reduce the problem to the smallest reproducible example you can share. If this is a request for MusicXML support that denigma does not yet implement, use the [MusicXML feature gap form](https://github.com/rpatters1/denigma/issues/new?template=musicxml-gap.yml) instead.
 
   - type: textarea
     id: summary
@@ -76,10 +76,10 @@ body:
     id: sample-files
     attributes:
       label: Minimal sample files
-      description: Upload the smallest input and output files that reproduce the bug. Append `.zip` to MUSX filenames without recompressing them; ZIP other unsupported formats.
+      description: Upload the smallest input and output files that reproduce the bug as a ZIP archive. For MUSX files, append `.zip` to the filename without recompressing it.
     validations:
       required: false
-      accept: ".zip,.gz,.tar.gz,.json,.log,.txt,.csv,.pdf,.png,.jpg,.jpeg,.gif,.svg,.webp"
+      accept: ".zip"
 
   - type: textarea
     id: diagnostics

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for suggesting an improvement. Describe the need independently of a particular implementation so that alternatives remain open. For missing MusicXML support, use the [MusicXML feature gap form](https://github.com/rpatters1/denigma/issues/new?template=musicxml-gap.yml) instead.
+        Thank you for suggesting an improvement. Describe the need independently of a particular implementation so that alternatives remain open. For missing MusicXML support, use the [MusicXML feature gap form](https://github.com/rpatters1/denigma/issues/new?template=musicxml-gap.yml) instead.
 
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,74 @@
+name: General feature request
+description: Suggest a new denigma capability or improvement
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. Describe the need independently of a particular implementation so that alternatives remain open. For missing MusicXML support, use the [MusicXML feature gap form](https://github.com/rpatters1/denigma/issues/new?template=musicxml-gap.yml) instead.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or need
+      description: Describe the limitation, workflow problem, or user need this feature would address. Explain who encounters it and why it matters.
+      placeholder: Currently, users cannot ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-behavior
+    attributes:
+      label: Proposed behavior
+      description: Describe what denigma should do. Focus on observable behavior and results; implementation suggestions are welcome but not required.
+      placeholder: denigma should ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-cases
+    attributes:
+      label: Use cases and acceptance criteria
+      description: Give concrete workflows or examples and explain how maintainers can verify that the feature is complete. Identify affected commands or output formats where relevant.
+      placeholder: |
+        Use case:
+
+        The feature is complete when:
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives and workarounds
+      description: Describe current workarounds or other solutions you considered, and why they are insufficient.
+    validations:
+      required: false
+
+  - type: textarea
+    id: examples
+    attributes:
+      label: Examples and additional context
+      description: Attach minimal example files, screenshots, links to relevant specifications, or related discussions. For MUSX files, append `.zip` to the filename without recompressing it.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: prior-search
+    attributes:
+      label: Prior search
+      description: Confirm that this feature is not already tracked in [open or closed GitHub issues](https://github.com/rpatters1/denigma/issues?q=is%3Aissue).
+      options:
+        - label: I searched both open and closed issues for this feature.
+          required: true
+
+  - type: checkboxes
+    id: sharing
+    attributes:
+      label: Permission to use attachments for testing
+      description: Public issue attachments can be viewed and downloaded by anyone. Test fixtures committed to denigma are distributed under the repository's [MIT License](https://github.com/rpatters1/denigma/blob/main/LICENSE).
+      options:
+        - label: If I attached example files, I own them or have authority to grant permission, and they contain no private or sensitive information.
+          required: true
+        - label: If I attached example files, I grant the denigma project permission to retain, copy, modify, minimize, and redistribute them in its public repository, including as automated test fixtures under the MIT License.
+          required: true

--- a/.github/ISSUE_TEMPLATE/musicxml-gap.yml
+++ b/.github/ISSUE_TEMPLATE/musicxml-gap.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for helping improve denigma's MusicXML support. Please provide a minimal, shareable example whenever possible. Reports with enough detail to reproduce and verify the requested behavior are much easier to act on.
+        Thank you for helping improve denigma's MusicXML support. Please provide a minimal, shareable example whenever possible. Reports with enough detail to reproduce and verify the requested behavior are much easier to act on.
 
   - type: textarea
     id: missing-feature

--- a/.github/ISSUE_TEMPLATE/musicxml-gap.yml
+++ b/.github/ISSUE_TEMPLATE/musicxml-gap.yml
@@ -1,0 +1,99 @@
+name: MusicXML feature gap
+description: Report MusicXML content that denigma cannot yet produce or represent correctly
+title: "[MusicXML gap]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve denigma's MusicXML support. Please provide a minimal, shareable example whenever possible. Reports with enough detail to reproduce and verify the requested behavior are much easier to act on.
+
+  - type: textarea
+    id: missing-feature
+    attributes:
+      label: Missing MusicXML feature
+      description: Describe the notation or semantic information that denigma cannot currently encode, and explain why it matters.
+      placeholder: Include the expected musical meaning and what denigma currently produces or omits.
+    validations:
+      required: true
+
+  - type: input
+    id: specification
+    attributes:
+      label: MusicXML specification reference
+      description: Link to the relevant MusicXML specification page, if known, or name the relevant elements and attributes.
+      placeholder: https://www.w3.org/2021/06/musicxml40/...
+    validations:
+      required: false
+
+  - type: textarea
+    id: correct-musicxml
+    attributes:
+      label: Correctly encoded MusicXML example
+      description: Paste a focused XML snippet in a fenced code block, or attach a minimal sample as a ZIP file. Explain which part demonstrates the requested encoding.
+      placeholder: |
+        ```xml
+        <example>...</example>
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: importers
+    attributes:
+      label: Importers that use this feature
+      description: Name one or more applications or libraries that consume this MusicXML feature. Include tested versions and describe the result you expect after import.
+      placeholder: |
+        - Application and version:
+        - Expected imported result:
+    validations:
+      required: true
+
+  - type: upload
+    id: musx-example
+    attributes:
+      label: MUSX example
+      description: Upload a minimal MUSX file that illustrates the need. Append `.zip` to its filename (for example, `example.musx.zip`); do not recompress it. Identify the relevant score location under Conversion details.
+    validations:
+      required: true
+      accept: ".zip"
+
+  - type: textarea
+    id: conversion-details
+    attributes:
+      label: Conversion details
+      description: Give the denigma version or commit, the source application's version, and the exact command or workflow used. Attach denigma's current output if it helps show the gap.
+      placeholder: |
+        - denigma version or commit:
+        - Source application and version:
+        - Command or workflow:
+        - Relevant location in the score:
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add screenshots, related discussions, known workarounds, or other information that may help implement and verify the feature.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: prior-search
+    attributes:
+      label: Prior search
+      description: Confirm that this request is not already tracked in the [MusicXML feature roadmap](https://github.com/rpatters1/denigma/blob/main/src/formats/musicxml/roadmap.md) or [GitHub issues](https://github.com/rpatters1/denigma/issues?q=is%3Aissue).
+      options:
+        - label: I searched the roadmap and both open and closed issues for this feature.
+          required: true
+
+  - type: checkboxes
+    id: sharing
+    attributes:
+      label: Permission to use attachments for testing
+      description: Public issue attachments can be viewed and downloaded by anyone. Test fixtures committed to denigma are distributed under the repository's [MIT License](https://github.com/rpatters1/denigma/blob/main/LICENSE).
+      options:
+        - label: I own the attached MUSX and MusicXML examples, or I have authority to grant the permissions below, and the files contain no private or sensitive information.
+          required: true
+        - label: I grant the denigma project permission to retain, copy, modify, minimize, and redistribute the attached examples in its public repository, including as automated test fixtures under the MIT License.
+          required: true

--- a/src/formats/musicxml/mx-api-gaps.md
+++ b/src/formats/musicxml/mx-api-gaps.md
@@ -58,16 +58,6 @@ Needed API shape: the same tie-notation data model requested above should also c
 
 ## Smart Shapes And Spanners
 
-### Spanner numbers are pooled per staff instead of per part
-
-MusicXML's `number-level` type states that spanner `number` attributes distinguish "concurrent objects of the same type when the objects overlap in MusicXML document order" within "a single musical part" — the staff plays no role in that scoping. The spec's own worked example is a piano part in which a cross-staff slur "will need a separate number from the mid-measure slurs because it overlaps those slurs in MusicXML document order," even though they are on different staves. Readers accordingly pair slur starts and stops by number within the part (MuseScore, for example, keeps one open-slur slot per number per part).
-
-`mx::impl::SpannerNumberResolver` (added by the unified spanner numbering change) draws numbers from a pool per *staff* per spanner class (`occupied[staffIndex][number]`). Two identity slurs that overlap in document order on different staves of the same part therefore both receive number 1. Minimal repro: a two-staff part with one whole-note slur per staff spanning measures 1-2 serializes as start@staff1, start@staff2, stop@staff1, stop@staff2 — all four emitted as `number="1"`. Readers mispair or drop the second slur, which presents as slurs attached to the wrong staff on multistaff instruments; cross-staff notes increase document-order overlap between the staves' slurs and make the collisions more frequent. Denigma supplies correct identity-based `SpannerNumber` values; the collision happens at write time inside mx.
-
-Needed API shape: none — this is a writer bug. The resolver's pools should be scoped per part and spanner class only (drop the staff dimension from `occupied`). The special-case logic that reserves a cross-staff spanner's number "in every staff pool it touches" then becomes unnecessary rather than needing repair.
-
-Status: filed as mx issue #350 with a PR; the fix is already applied on the rpatters1/mx fork that Denigma builds against, and `MusicXmlSmartShapes.OverlappingSlursAcrossStavesCarryDistinctNumbers` pins it. Remove this entry when the PR merges upstream.
-
 ### Octave shifts beyond two octaves
 
 MusicXML `<octave-shift>` supports any shift via the `size` attribute (8, 15, 22, ...). Finale has no built-in 22ma smart shape, but custom lines classified as three-octave shifts ("22ma"/"22mb") can occur.
@@ -80,7 +70,7 @@ Needed API shape: either additional `OttavaType` values for 22ma/22mb or a numer
 
 MusicXML `<octave-shift>` accepts the position and print-object/print-style attributes on the start element.
 
-`mx::api::OttavaStart::spannerStart` carries `positionData` and `printData`, but `DirectionWriter::emitOttavaStart` applies only `LineData` and the spanner number (the number drop was fixed by the unified spanner numbering change), so the start's `positionData` and `printData` are still silently dropped. Denigma does not currently populate these fields on ottava starts, so this is a low-priority gap.
+`mx::api::OttavaStart::spannerStart` carries `positionData` and `printData`, but `DirectionWriter::emitOttavaStart` applies only `LineData` and the spanner number, so the start's `positionData` and `printData` are silently dropped. Denigma does not currently populate these fields on ottava starts, so this is a low-priority gap.
 
 Needed API shape: none — this is a writer bug. `emitOttavaStart` should apply position and print data like the bracket, dashes, and ottava-stop writers do.
 

--- a/src/formats/musicxml/roadmap.md
+++ b/src/formats/musicxml/roadmap.md
@@ -2,6 +2,18 @@
 
 This is the implementation backlog for larger user-facing MusicXML export features. It is not a version plan or a dependency order. Keep concrete `mx::api` limitations in [mx-api-gaps.md](mx-api-gaps.md).
 
+## Compressed MusicXML (`.mxl`) output
+
+Export standards-compliant compressed MusicXML in addition to uncompressed `.musicxml` files. Each archive should contain an uncompressed `mimetype` entry first, a `META-INF/container.xml` file that identifies the root MusicXML document, and the compressed score document. The existing ZIP utilities and MXL massage support should supply most of the required archive infrastructure.
+
+Initially, write one `.mxl` archive for each score or part document that Denigma currently emits separately. Packaging the score and all linked parts into one MusicXML 4.0 archive through `<part-link>` can be considered as a later extension rather than a prerequisite for basic compressed output.
+
+## Nontraditional and microtonal key signatures
+
+Export Finale nontraditional key signatures through MusicXML's ordered `<key-step>`, `<key-alter>`, and optional `<key-accidental>` values instead of degrading them to zero fifths. Begin with custom 12-EDO signatures, for which MUSX DOM can provide the key map and `mx::api::KeyData::nonTraditional` already provides a writer path.
+
+Extend the same mapping to microtonal key signatures by converting Finale's EDO divisions into MusicXML semitone alterations and suitable accidental values. Preserve the effective written or concert-pitch signature independently for each staff, as the exporter already does for traditional keys.
+
 ## Visible cue notes and rests
 
 Export cue material that is visible in the target score or part as MusicXML `<cue/>` notes and rests. Skip cue material hidden in that target context. `mx::api::NoteData::isCue` already writes and reads cue, grace-cue, and cue-rest forms, so this is a Denigma policy and mapping task rather than an MX API feature.

--- a/tests/musicxml/test_smartshapes.cpp
+++ b/tests/musicxml/test_smartshapes.cpp
@@ -188,8 +188,8 @@ TEST(MusicXmlSmartShapes, SlursOverbarsMatchReference)
 /// by number within the part, so a collision mispairs them (typically visible as
 /// slurs jumping between the staves of a multistaff instrument). The fixture's
 /// staff-1 slur (m5-m6) is open when the staff-2 slur (m6) starts, so they must
-/// take different numbers. Requires mx's part-scoped spanner number pools
-/// (mx PR for issue #350; see mx-api-gaps.md).
+/// take different numbers. This pins the part-scoped spanner number pools from
+/// mx issue #350 and PR #351.
 TEST(MusicXmlSmartShapes, OverlappingSlursAcrossStavesCarryDistinctNumbers)
 {
     setupTestDataPaths();


### PR DESCRIPTION
## Summary

- Add structured issue forms for bug reports, general feature requests, and MusicXML feature gaps.
- Require reproducibility details, prior-issue searches, and permission to retain attached examples as public MIT-licensed test fixtures.
- Provide dedicated ZIP upload fields for MUSX files and other reproduction fixtures.
- Add compressed `.mxl` output and nontraditional/microtonal key signatures to the MusicXML feature roadmap.
- Remove the resolved MX spanner-number gap and update related comments to reference MX issue #350 and PR #351 directly.

## Validation

- Parsed all three issue forms successfully as YAML.
- Verified unique form structure and required attachment permissions.
- `git diff --check origin/main` passes.
- No automated tests were run because the changes affect documentation, GitHub configuration, and test comments only.
