### PR TITLE
MNX: demote format-gap notifications below Warning

### DIFF
--- a/src/formats/mnx/mnx.cpp
+++ b/src/formats/mnx/mnx.cpp
@@ -84,7 +84,7 @@ void MnxMusxMapping::logDiscardedCueLayerFrame(LayerIndex layer)
     discardedCueFrames++;
     logMessage(LogMsg() << "discarded cue material detected by --cue-layer in measure "
         << current.meas << ", staff " << current.staff << ", layer " << (layer + 1)
-        << "; MNX does not currently support cues.");
+        << "; MNX does not currently support cues.", MessageSeverity::Verbose);
 }
 
 void MnxMusxMapping::logDiscardedHeuristicCueStaffMeasure()
@@ -92,7 +92,7 @@ void MnxMusxMapping::logDiscardedHeuristicCueStaffMeasure()
     discardedCueFrames++;
     logMessage(LogMsg() << "discarded cue material detected heuristically in measure "
         << current.meas << ", staff " << current.staff
-        << "; MNX does not currently support cues.");
+        << "; MNX does not currently support cues.", MessageSeverity::Verbose);
 }
 
 void MnxMusxMapping::setCurrentMeasureStaff(const MusxInstance<others::Measure>& musxMeasure, StaffCmper staffCmper)
@@ -264,7 +264,7 @@ static std::unique_ptr<mnxdom::Document> createMnxDocument(const CommandInputDat
     }
     if (context->discardedCueFrames > 0) {
         denigmaContext.logMessage(LogMsg() << "discarded " << context->discardedCueFrames
-            << " cue frames because MNX does not currently support cues.");
+            << " cue frames because MNX does not currently support cues.", MessageSeverity::Verbose);
     }
 
     return std::move(context->mnxDocument);

--- a/src/formats/mnx/mnx_articulations.cpp
+++ b/src/formats/mnx/mnx_articulations.cpp
@@ -393,7 +393,7 @@ void finalizeArpeggios(const MnxMusxMappingPtr& context)
         const auto bottomPart = findMnxPartForNote(context, bottomNote.value());
         if (!topPart || !bottomPart) {
             context->logMessage(LogMsg() << "skipping arpeggio because its note span includes a staff that is not assigned to an MNX part.",
-                MessageSeverity::Warning);
+                MessageSeverity::Info);
             continue;
         }
 
@@ -403,7 +403,7 @@ void finalizeArpeggios(const MnxMusxMappingPtr& context)
         } else {
             targetParts = findAffectedMnxPartsForArpeggio(context, candidate);
             context->logMessage(LogMsg() << "splitting arpeggio across MNX part boundary into "
-                << mnxPartDisplayList(context, targetParts) << ".", MessageSeverity::Info);
+                << mnxPartDisplayList(context, targetParts) << ".", MessageSeverity::Verbose);
         }
 
         bool emittedAny = false;

--- a/src/formats/mnx/mnx_expressions.cpp
+++ b/src/formats/mnx/mnx_expressions.cpp
@@ -324,7 +324,7 @@ void recordMeasureRepeatCount(const MnxMusxMappingPtr& context, const MusxInstan
         context->logMessage(LogMsg() << "Measure repeat counter " << count
             << " disagrees with counter " << it->second << " on another staff of the same part;"
             " MNX has one counter per part measure, so only the first is exported.",
-            MessageSeverity::Warning);
+            MessageSeverity::Verbose);
     }
 }
 } // namespace

--- a/src/formats/mnx/mnx_layouts.cpp
+++ b/src/formats/mnx/mnx_layouts.cpp
@@ -212,7 +212,8 @@ void createLayouts(const MnxMusxMappingPtr& context)
         const bool layoutIsCalculated = linkedPart->isLayoutCalculated();
         if (!layoutIsCalculated) {
             context->denigmaContext->logMessage(LogMsg() << "Part \"" << calcLinkedPartDisplayName(linkedPart)
-                << "\" has an uncalculated page layout; omitting its per-system layouts and pages.");
+                << "\" has an uncalculated page layout; omitting its per-system layouts and pages.",
+                MessageSeverity::Verbose);
         }
         const SystemCmper maxSystem = layoutIsCalculated ? SystemCmper(staffSystems.size()) : BASE_SYSTEM_ID;
         for (SystemCmper sysId = minSystem; sysId <= maxSystem; sysId++) { //NOTE: unusual loop limits are *on purpose*

--- a/src/formats/mnx/mnx_parts.cpp
+++ b/src/formats/mnx/mnx_parts.cpp
@@ -169,7 +169,7 @@ static std::optional<ClefIndex> createClef(
         return clefIndex;
     } else {
         context->logMessage(LogMsg() << "Clef char " << int(musxClef->clefChar) << " has no clef info. " << " (glyph name is " << clef.glyphName.value_or("") << ")"
-            << " Clef change was skipped.", MessageSeverity::Warning);
+            << " Clef change was skipped.", MessageSeverity::Verbose);
     }
     return std::nullopt;
 };
@@ -304,7 +304,7 @@ static int calcPartRepeatSpan(const MnxMusxMappingPtr& context, mnxdom::Part& pa
         if (partSpan && partSpan.value() != staffSpan) {
             context->logMessage(LogMsg() << mnxPartDisplayName(context, part) << " has a measure repeat in measure "
                 << musxMeasure->getCmper() << " that does not apply to every staff of the part;"
-                " MNX has no per-staff measure repeat, so it is not exported.", MessageSeverity::Warning);
+                " MNX has no per-staff measure repeat, so it is not exported.", MessageSeverity::Verbose);
             return 0;
         }
         partSpan = staffSpan;

--- a/src/formats/mnx/mnx_sequences.cpp
+++ b/src/formats/mnx/mnx_sequences.cpp
@@ -307,7 +307,7 @@ static void createNote(const MnxMusxMappingPtr& context, mnxdom::sequence::Event
             mnxNote.set_staff(mnxNoteStaff.value());
         } else {
             context->logMessage(LogMsg() << " note has cross-staffing to a staff (" << noteStaff
-                << ") that is not included in the MNX part.", MessageSeverity::Warning);
+                << ") that is not included in the MNX part.", MessageSeverity::Info);
         }
     }
     createTies(context, mnxNote, musxNote);
@@ -438,7 +438,7 @@ static std::optional<mnxdom::sequence::Event> createEvent(const MnxMusxMappingPt
             mnxEvent.set_staff(mnxPartStaff.value());
         } else {
             context->logMessage(LogMsg() << " entry has cross-staffing to a staff (" << crossedStaffId.value()
-                << ") that is not included in the MNX part.", MessageSeverity::Warning);
+                << ") that is not included in the MNX part.", MessageSeverity::Info);
         }
     }
     const auto [freezeStem, upStem] = musxEntryInfo.calcEntryStemSettings();

--- a/tests/mnx/test_parts.cpp
+++ b/tests/mnx/test_parts.cpp
@@ -249,7 +249,8 @@ TEST(MnxParts, CueLayer)
     setupTestDataPaths();
     std::filesystem::path inputPath;
     copyInputToOutput("forced_bass_clef.musx", inputPath);
-    ArgList args = { DENIGMA_NAME, "export", pathString(inputPath), "--mnx", "--cue-layer", "1", "--no-validate" };
+    // The cue notifications are verbose-only, so --verbose is required to observe them.
+    ArgList args = { DENIGMA_NAME, "export", pathString(inputPath), "--mnx", "--cue-layer", "1", "--no-validate", "--verbose" };
     checkStderr(std::vector<std::string>{
         "discarded cue material detected by --cue-layer in measure 2, staff 1, layer 1; MNX does not currently support cues.",
         "discarded 1 cue frames because MNX does not currently support cues."


### PR DESCRIPTION
## Summary

Messages that report an **MNX model gap** rather than a problem with the input or with denigma were logged as warnings, which cluttered the post-conversion diagnostic list in denigma-online. This reserves `Warning` for conditions actually worth a reader's attention.

denigma-online already draws this distinction: `visibleDiagnostics()` filters `verbose` out of the on-screen list while `diagnosticReport()` retains every severity. Since the wasm bridge sets `verbose = true` and collects through `logCallback`, the demoted messages disappear from the UI but remain in the downloadable diagnostic report.

## Changes

**Warning → Verbose** (lossy but correct output, nothing the user or denigma can act on)

| Message | Location |
|---|---|
| cue material discarded (per-frame, `--cue-layer`) | `mnx.cpp` |
| cue material discarded (per-staff-measure, heuristic) | `mnx.cpp` |
| `discarded N cue frames` summary | `mnx.cpp` |
| clef char has no clef info — percussion and tab clefs have no MNX sign yet | `mnx_parts.cpp` |
| per-staff measure repeat, which MNX cannot express | `mnx_parts.cpp` |
| measure repeat counters disagree across staves of one part | `mnx_expressions.cpp` |

**Info → Verbose**

| Message | Location |
|---|---|
| arpeggio split across an MNX part boundary | `mnx_articulations.cpp` |
| uncalculated part page layout, a valid Finale document state | `mnx_layouts.cpp` |

**Warning → Info**

| Message | Location |
|---|---|
| arpeggio skipped, span includes an unassigned staff | `mnx_articulations.cpp` |
| note cross-staffed outside the MNX part | `mnx_sequences.cpp` |
| entry cross-staffed outside the MNX part | `mnx_sequences.cpp` |

## Left at Warning

Deliberately unchanged, since these report bad source data or denigma-side failures rather than MNX gaps:

- Malformed measure repeats: reaching before the first measure, past the last, nested inside another repeat, or an orphan counter
- Entry exceeds measure length; tuplet exceeds measure length
- Irreducible time signature fraction, invalid syllable number, inexact duration approximation, insufficient flags/beams for tremolo
- Split-instrument limits — Finale changes instruments only at barlines, so these should be rare to impossible
- Internal resolution failures, and schema/semantic validation errors

## Testing

`MnxParts.CueLayer` asserted on two of the demoted cue strings, so it now passes `--verbose`. Full suite passes: 392/392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)