### PR TITLE
Fix additive chord suffix classification

### DIFF
--- a/src/classify/chords.cpp
+++ b/src/classify/chords.cpp
@@ -234,6 +234,16 @@ void classifyText(ChordSuffixClassification& result)
     if (parseText == "ped") { result.quality = Quality::Pedal; return; }
     if (parseText == "nc" || parseText == "n.c.") { result.quality = Quality::None; return; }
     if (parseText == "m7b5") { result.quality = Quality::MinorSeventh; addDegree(result, 5, DegreeType::Alter, -1); return; }
+    if (parseText == "+") { result.quality = Quality::Augmented; return; }
+    if (parseText == "+6") { result.quality = Quality::MajorSixth; return; }
+    if (parseText.size() > 1 && parseText.front() == '+'
+        && std::isdigit(static_cast<unsigned char>(parseText[1])) && parseText != "+5") {
+        if (parseDegrees(std::string_view(parseText).substr(1), result)) {
+            result.quality = Quality::Major;
+            return;
+        }
+        result.degrees.clear();
+    }
     const std::pair<std::string_view, Quality> suspendedPrefixes[] {
         { "13sus4", Quality::SuspendedFourth }, { "11sus4", Quality::SuspendedFourth },
         { "9sus4", Quality::SuspendedFourth }, { "7sus4", Quality::SuspendedFourth },

--- a/tests/test_chords.cpp
+++ b/tests/test_chords.cpp
@@ -140,6 +140,40 @@ TEST(ChordSuffixClassifier, ClassifiesAnAbsentSuffixAsMajor)
     EXPECT_EQ(*classification.quality, denigma::classify::chord::Quality::Major);
 }
 
+TEST(ChordSuffixClassifier, TreatsCompoundPlusSuffixesAsMajorAddChords)
+{
+    const auto context = makeFontContext("Times New Roman");
+    const auto classify = [&context](std::u32string_view text) {
+        auto suffix = makeSuffix(context, text.front());
+        for (size_t index = 1; index < text.size(); ++index) {
+            appendSuffixElement(suffix, context, text[index], static_cast<Inci>(index));
+        }
+        return denigma::classify::classifyChordSuffix(suffix);
+    };
+
+    const auto majorSixth = classify(U"+6");
+    ASSERT_TRUE(majorSixth.quality);
+    EXPECT_EQ(*majorSixth.quality, denigma::classify::chord::Quality::MajorSixth);
+    EXPECT_TRUE(majorSixth.degrees.empty());
+
+    const auto majorAddTwo = classify(U"+2");
+    ASSERT_TRUE(majorAddTwo.quality);
+    EXPECT_EQ(*majorAddTwo.quality, denigma::classify::chord::Quality::Major);
+    ASSERT_EQ(majorAddTwo.degrees.size(), 1);
+    EXPECT_EQ(majorAddTwo.degrees.front().value, 2);
+    EXPECT_EQ(majorAddTwo.degrees.front().type, denigma::classify::chord::Degree::Type::Add);
+}
+
+TEST(ChordSuffixClassifier, KeepsBarePlusAsAugmented)
+{
+    const auto context = makeFontContext("Times New Roman");
+    const auto classification = denigma::classify::classifyChordSuffix(makeSuffix(context, U'+'));
+
+    ASSERT_TRUE(classification.quality);
+    EXPECT_EQ(*classification.quality, denigma::classify::chord::Quality::Augmented);
+    EXPECT_TRUE(classification.degrees.empty());
+}
+
 TEST(ChordSuffixClassifier, ConvertsLegacyFinaleChordSymbols)
 {
     const auto context = makeFontContext("Maestro");


### PR DESCRIPTION
## Summary

- Treat compound +N chord suffixes such as +2 and +6 as major chords with added degrees.
- Map +6 to MusicXML major-sixth.
- Preserve bare + and +5 as augmented forms.
- Add focused regression coverage.

## Verification

- cmake --build build --target denigma_tests -j2
- denigma_tests from tests/data: 414 tests passed.
- Existing MusicXML chord fixture tests passed.

Fixes #111