### PR TITLE
Export high-impact MusicXML metadata

### DIFF
--- a/src/formats/musicxml/design-decisions.md
+++ b/src/formats/musicxml/design-decisions.md
@@ -28,9 +28,9 @@ A note's `default-x`, a `<measure>`'s `width`, a slur's `bezier-x` and `bezier-y
 
 Denigma does export position for anchors Finale stores directly. Page text blocks carry absolute page coordinates in the document, so `<credit-words>` receives real `default-x` and `default-y` values derived from the page margins and the text block's assignment. That is stored authorial placement, and it is the clearest illustration of where the line falls.
 
-### System breaks come from authored sources only
+### System and page breaks come from authored sources only
 
-`createSystemBreaks` derives `<print new-system="yes">` from the per-measure "Begin a New Staff System" flag and from `others::SystemLock`, and from nothing else. It never reads the resolved `others::StaffSystem` list.
+`createSystemBreaks` derives `<print new-system="yes">` from the per-measure "Begin a New Staff System" flag and from `others::SystemLock`. `createPageBreaks` derives `<print new-page="yes">` from the per-measure page-break flag. Neither reads the resolved `others::StaffSystem` or `others::Page` lists. When both break types occur on one measure, the page break takes precedence because it inherently starts a new system.
 
 A system boundary that exists only because Finale's engraver happened to fill a line there is layout, and re-emitting it freezes one particular rendering into a file the importer is about to re-flow. A lock or an explicit break flag is something the author asked for, and it survives the round trip.
 

--- a/src/formats/musicxml/musicxml_defaults.cpp
+++ b/src/formats/musicxml/musicxml_defaults.cpp
@@ -229,6 +229,21 @@ void createSystemBreaks(const MusicXmlMusxMapping& context)
     }
 }
 
+void createPageBreaks(const MusicXmlMusxMapping& context)
+{
+    const auto measures = context.document->getOthers()->getArray<others::Measure>(context.forPartId);
+    for (size_t index = 1; index < measures.size(); ++index) {
+        if (!measures[index]->pageBreak) {
+            continue;
+        }
+        auto& layout = context.musicXmlScore->layout[static_cast<mx::api::MeasureIndex>(index)];
+        layout.page.newPage = mx::api::Bool::yes;
+        // A page break inherently starts a system, so avoid a redundant new-system attribute when
+        // both authored flags or a system lock target the same measure.
+        layout.system.newSystem = mx::api::Bool::unspecified;
+    }
+}
+
 } // namespace
 
 void createDefaults(const MusicXmlMusxMapping& context)
@@ -245,6 +260,7 @@ void createDefaults(const MusicXmlMusxMapping& context)
     createPageLayoutData(context, *pagePrefs, combinedSystemScaling);
     createSystemLayoutData(context, *pagePrefs);
     createSystemBreaks(context);
+    createPageBreaks(context);
     createAppearance(context);
     createFontData(context);
 }

--- a/src/formats/musicxml/musicxml_measures.cpp
+++ b/src/formats/musicxml/musicxml_measures.cpp
@@ -388,11 +388,60 @@ int musicXmlKeyFifths(
         return 0;
     }
     if (!keySignature->isLinear()) {
-        context.logMessage(LogMsg() << "Skipping unsupported non-linear key signature " << keySignature->getKeyMode()
-            << " in measure " << measureId << ".", MessageSeverity::Info);
         return 0;
     }
     return keySignature->getAlteration(enumConvert<KeySignature::KeyContext>(pitchContext));
+}
+
+mx::api::Accidental musicXmlAccidentalFor12EdoAlteration(int alteration)
+{
+    constexpr int kTripleFlat = -3;
+    constexpr int kDoubleFlat = -2;
+    constexpr int kFlat = -1;
+    constexpr int kSharp = 1;
+    constexpr int kDoubleSharp = 2;
+    constexpr int kTripleSharp = 3;
+    switch (alteration) {
+        case kTripleFlat: return mx::api::Accidental::tripleFlat;
+        case kDoubleFlat: return mx::api::Accidental::flatFlat;
+        case kFlat: return mx::api::Accidental::flat;
+        case kSharp: return mx::api::Accidental::sharp;
+        case kDoubleSharp: return mx::api::Accidental::doubleSharp;
+        case kTripleSharp: return mx::api::Accidental::tripleSharp;
+        default: return mx::api::Accidental::none;
+    }
+}
+
+void populateNonTraditional12EdoKey(
+    const MusicXmlMusxMapping& context,
+    const MusxInstance<KeySignature>& keySignature,
+    MeasCmper measureId,
+    mx::api::KeyData& key)
+{
+    const auto mode = keySignature->getKeyMode();
+    const auto amounts = context.document->getOthers()->get<others::AcciAmountSharps>(SCORE_PARTID, mode);
+    const auto order = context.document->getOthers()->get<others::AcciOrderSharps>(SCORE_PARTID, mode);
+    if (!amounts || !order) {
+        context.logMessage(LogMsg() << "Skipping incomplete non-linear key signature " << mode
+            << " in measure " << measureId << ".", MessageSeverity::Info);
+        return;
+    }
+
+    for (size_t index = 0; index < amounts->values.size() && index < order->values.size(); ++index) {
+        const int alteration = amounts->values[index];
+        if (alteration == 0) {
+            break;
+        }
+        const auto noteNameIndex = order->values[index];
+        if (noteNameIndex >= music_theory::STANDARD_DIATONIC_STEPS) {
+            context.logMessage(LogMsg() << "Skipping invalid pitch index " << noteNameIndex << " in non-linear key signature "
+                << mode << " in measure " << measureId << ".", MessageSeverity::Info);
+            continue;
+        }
+        const auto noteName = static_cast<music_theory::NoteName>(noteNameIndex);
+        key.nonTraditional.emplace_back(
+            enumConvert<mx::api::Step>(noteName), alteration, 0.0, musicXmlAccidentalFor12EdoAlteration(alteration));
+    }
 }
 
 mx::api::KeyData createKeyData(
@@ -403,6 +452,12 @@ mx::api::KeyData createKeyData(
     bool staffHidesKeySignature)
 {
     auto key = mx::api::KeyData{};
+    const bool keySignatureIsVisible = !(keySignature->keyless || keySignature->hideKeySigShowAccis || staffHidesKeySignature);
+    if (keySignatureIsVisible && keySignature->isNonLinear()
+        && keySignature->calcEDODivisions() == music_theory::STANDARD_12EDO_STEPS) {
+        populateNonTraditional12EdoKey(context, keySignature, measureId, key);
+        return key;
+    }
     key.fifths = musicXmlKeyFifths(context, keySignature, measureId, pitchContext, staffHidesKeySignature);
     key.mode = musicXmlKeyModeFromMusxKeySignature(keySignature, staffHidesKeySignature);
     return key;

--- a/src/formats/musicxml/musicxml_parts.cpp
+++ b/src/formats/musicxml/musicxml_parts.cpp
@@ -64,6 +64,7 @@ void populatePartMetadata(MusicXmlMusxMapping& context, mx::api::PartData& part,
     context.partIdToPitchContext[id] = MusicXmlPitchContext::Concert;
     if (const auto soundId = musicXmlSoundIdFromInstrumentUuid(staff->instUuid)) {
         part.instrumentData.soundID = *soundId;
+        part.instrumentData.name = mx::api::SoundIDToString(*soundId);
     }
 
     const auto [transpositionDisp, transpositionAlt] = staff->calcTranspositionInterval();
@@ -80,6 +81,12 @@ void populatePartMetadata(MusicXmlMusxMapping& context, mx::api::PartData& part,
     }
 
     const auto fullName = utils::trimAscii(staff->getFullInstrumentName(EnigmaString::AccidentalStyle::Unicode));
+    if (part.instrumentData.name.empty()) {
+        part.instrumentData.name = utils::trimNewLineFromString(fullName);
+        if (part.instrumentData.name.empty()) {
+            part.instrumentData.name = staff->instUuid;
+        }
+    }
     if (!fullName.empty()) {
         part.name = utils::trimNewLineFromString(fullName);
         if (!staff->showNamesForPart(context.finaleOptions.forPartId)) {

--- a/src/formats/musicxml/roadmap.md
+++ b/src/formats/musicxml/roadmap.md
@@ -20,12 +20,6 @@ Export Finale nontraditional key signatures through MusicXML's ordered `<key-ste
 
 Extend the same mapping to microtonal key signatures by converting Finale's EDO divisions into MusicXML semitone alterations and suitable accidental values. Preserve the effective written or concert-pitch signature independently for each staff, as the exporter already does for traditional keys.
 
-## Visible cue notes and rests
-
-Export cue material that is visible in the target score or part as MusicXML `<cue/>` notes and rests. Skip cue material hidden in that target context. `mx::api::NoteData::isCue` already writes and reads cue, grace-cue, and cue-rest forms, so this is a Denigma policy and mapping task rather than an MX API feature.
-
-MusicXML export identifies cue layers, suppresses cue entries and their associated expressions when hidden in the requested context, and sends visible cue entries and expressions through their normal mapping paths. Notes and rests set `isCue`. Cue ties remain blocked on the visual-tie API limitation documented in [mx-api-gaps.md](mx-api-gaps.md); Denigma does not maintain a separate workaround path. MNX keeps its current cue-discard behavior because it does not yet support cues.
-
 ## Instruments, transpositions, and instrument changes
 
 Treat a part's instrument as one subject rather than the handful of unrelated fields it is today. `populatePartMetadata` sets only `instrumentData.uniqueId` and, when the staff's `instUuid` is recognized, `instrumentData.soundID`. Everything else about the instrument is left default.
@@ -111,18 +105,6 @@ Export single-note tremolos with six, seven, or eight slashes. `mx::api` models 
 Finale can spell the higher counts only by stacking: a Shape Designer shape that draws several tremolo glyphs, or two tremolo articulations assigned to one entry. Recognizing the first requires a new `KnownShapeDefType` and recognizer in MUSX DOM, and a stack with variable count and spacing is a fuzzier recognition target than the fixed patterns already there. Recognizing the second requires entry-level aggregation plus vertical-offset geometry, since two tremolo articulations on one entry may equally well be two separate marks.
 
 This is gated on evidence. Revisit it when a real-world Finale file actually spells such a tremolo; that file also settles which of the two routes is worth supporting.
-
-## Hard page breaks
-
-Export Finale's explicit page breaks as MusicXML `<print new-page="yes">`. Denigma writes no `new-page` attribute today, and populates no `mx::api::PageData` at all, so a document's authored page breaks are lost even though its system breaks survive.
-
-`others::Measure::pageBreak` is the source, and it is the page equivalent of the `beginNewSystem` flag that `createSystemBreaks` already reads: a saved per-measure setting that resolves nothing and therefore stays trustworthy even in a part whose page layout Finale never calculated. Take it and nothing else. Breaks recoverable only from the resolved `others::Page` and `others::StaffSystem` records are engraver output, and exporting them is ruled out by the authored-sources decision in [design-decisions.md](design-decisions.md); once this lands, update that document's break entry to cover pages as well as systems.
-
-No MX API work is needed. `mx::api::PageData::newPage` writes the attribute, and `ScoreData::layout` already carries the per-measure `LayoutData` that `createSystemBreaks` populates, so a page break is one more field on an entry that path may already be creating.
-
-Two details need deciding rather than assuming. MUSX notes that Finale's behavior is unpredictable when `pageBreak` is set on a measure that is not the first of its system, so decide what such a measure means before mapping it; MusicXML has no equivalent ambiguity, since `new-page` starts a system too. Related, a measure carrying both flags should not produce contradictory output: confirm whether `new-page="yes"` alone suffices or whether `new-system="yes"` should accompany it.
-
-`PageData` also carries `pageNumber` and `pageLayoutData`, which Finale's own export uses on its page-break prints. Those are separate questions from the break itself and should not be folded in here; see the page-specific layout note under text and custom-line fidelity below.
 
 ## Extend the font-availability assertion to MNX
 

--- a/src/formats/musicxml/roadmap.md
+++ b/src/formats/musicxml/roadmap.md
@@ -20,15 +20,15 @@ Extend the nontraditional key-signature mapping to microtonal signatures by conv
 
 ## Instruments, transpositions, and instrument changes
 
-Treat a part's instrument as one subject rather than the handful of unrelated fields it is today. `populatePartMetadata` sets only `instrumentData.uniqueId` and, when the staff's `instUuid` is recognized, `instrumentData.soundID`. Everything else about the instrument is left default.
+Treat a part's instrument as one subject rather than the handful of unrelated fields it is today. `populatePartMetadata` sets `instrumentData.uniqueId`, its required name, and, when the staff's `instUuid` is recognized, `instrumentData.soundID`. `soloOrEnsemble` remains unset even though Finale knows which staves are solo.
 
-The visible defect is the name. `mx::api::InstrumentData::name` and `abbreviation` are never set, so every `<score-instrument>` carries an empty `<instrument-name/>`, a required element with nothing in it. Finale writes its playback device name there; the staff's full and abbreviated names, or the name of the Finale instrument behind `instUuid`, are the better sources. `soloOrEnsemble` is likewise unset even though Finale knows which staves are solo.
+The instrument name uses the standardized SoundID string when one is available, allowing consumers to localize the semantic identifier. It falls back to Finale's authored full instrument name and then to the raw instrument UUID. Do not add an English-language UUID-to-name table to Denigma or MUSX DOM.
 
 Instrument sound coverage is partial in a way that hides itself. `musicXmlSoundIdFromInstrumentUuid` maps a fixed table of Finale instrument uuids, several entries are commented out, and an unrecognized uuid simply yields no `<instrument-sound>` with no diagnostic. Decide whether an unmapped instrument deserves a Verbose log, and extend the table.
 
 Transposition is exported once per part, from the staff that was current when the part was built, and gated on `showTransposed`. Finale can change an instrument's transposition mid-piece through a staff style, and nothing captures that. The related concert-score `<for-part>` support is an MX API gap; see [mx-api-gaps.md](mx-api-gaps.md).
 
-Instrument changes are the largest piece and are blocked upstream: `mx::api::PartData` holds exactly one `InstrumentData` for the whole part, so neither a mid-piece instrument change nor two simultaneous instruments can be expressed. That limitation, and the multiple-`<score-instrument>` model needed to lift it, are described under instrument changes within a part in [mx-api-gaps.md](mx-api-gaps.md). Naming, `soloOrEnsemble`, sound coverage, and initial transposition can all proceed ahead of it.
+Instrument changes are the largest piece and are blocked upstream: `mx::api::PartData` holds exactly one `InstrumentData` for the whole part, so neither a mid-piece instrument change nor two simultaneous instruments can be expressed. That limitation, and the multiple-`<score-instrument>` model needed to lift it, are described under instrument changes within a part in [mx-api-gaps.md](mx-api-gaps.md). `soloOrEnsemble`, sound coverage, and initial transposition can all proceed ahead of it.
 
 Two neighbouring items overlap this one and should stay separate. MIDI channels below covers the playback assignment that hangs off the instrument, and percussion covers the per-note instrument identity that drum kits need.
 

--- a/src/formats/musicxml/roadmap.md
+++ b/src/formats/musicxml/roadmap.md
@@ -14,11 +14,9 @@ Add a MusicXML export option that selects whether an explicitly positioned whole
 
 The default should remain Finale-compatible and apply no adjustment, matching round trips through Finale and MuseScore. The optional SMuFL-origin behavior should use `calcFinaleToSmuflRestPositionOffset`, matching Dorico's current interpretation. Apply the selected convention consistently to ordinary and complete-measure whole rests; other rest durations are unaffected.
 
-## Nontraditional and microtonal key signatures
+## Microtonal key signatures
 
-Export Finale nontraditional key signatures through MusicXML's ordered `<key-step>`, `<key-alter>`, and optional `<key-accidental>` values instead of degrading them to zero fifths. Begin with custom 12-EDO signatures, for which MUSX DOM can provide the key map and `mx::api::KeyData::nonTraditional` already provides a writer path.
-
-Extend the same mapping to microtonal key signatures by converting Finale's EDO divisions into MusicXML semitone alterations and suitable accidental values. Preserve the effective written or concert-pitch signature independently for each staff, as the exporter already does for traditional keys.
+Extend the nontraditional key-signature mapping to microtonal signatures by converting Finale's EDO divisions into MusicXML semitone alterations and suitable accidental values. Preserve the effective written or concert-pitch signature independently for each staff, as the exporter already does for traditional keys.
 
 ## Instruments, transpositions, and instrument changes
 

--- a/tests/musicxml/test_defaults.cpp
+++ b/tests/musicxml/test_defaults.cpp
@@ -284,3 +284,20 @@ TEST(MusicXmlDefaults, UncalculatedPartLayoutKeepsScoreSystemBreaks)
         EXPECT_EQ(countSystemBreaks(partPath), 0);
     }
 }
+
+TEST(MusicXmlDefaults, ExportsAuthoredPageBreaks)
+{
+    setupTestDataPaths();
+
+    const auto outputPath = exportMusicXmlFixture("musicxml/page70-staff82ev.musx");
+    const auto score = loadScoreData(outputPath);
+    ASSERT_TRUE(score);
+
+    const auto pageBreaks = std::count_if(score->layout.begin(), score->layout.end(), [](const auto& entry) {
+        return entry.second.page.newPage == mx::api::Bool::yes;
+    });
+    EXPECT_EQ(pageBreaks, 1);
+    EXPECT_TRUE(std::none_of(score->layout.begin(), score->layout.end(), [](const auto& entry) {
+        return entry.second.page.newPage == mx::api::Bool::yes && entry.second.system.newSystem != mx::api::Bool::unspecified;
+    }));
+}

--- a/tests/musicxml/test_parts.cpp
+++ b/tests/musicxml/test_parts.cpp
@@ -22,6 +22,7 @@
 #include <filesystem>
 #include <map>
 #include <optional>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -30,8 +31,10 @@
 #include "core/denigma.h"
 #include "core/musx_reader.h"
 #include "formats/musicxml/musicxml.h"
+#include "mx/api/DocumentManager.h"
 #include "mx/api/ScoreData.h"
 #include "musicxml_test.h"
+#include "pugixml.hpp"
 #include "test_utils.h"
 
 using namespace denigma;
@@ -708,6 +711,53 @@ TEST(MusicXmlParts, CustomLinearKeySignaturesExportDiatonicModes)
         SCOPED_TRACE("measure " + std::to_string(measureIndex + 1));
         ASSERT_EQ(measures[measureIndex].keys.size(), 1);
         EXPECT_EQ(measures[measureIndex].keys.front().mode, expectedModes[measureIndex]);
+    }
+}
+
+TEST(MusicXmlParts, NonTraditional12EdoKeySignaturesPreserveAccidentalOrder)
+{
+    setupTestDataPaths();
+
+    const auto score = createScoreDataFromMusxPath(std::filesystem::path(MUSX_TEST_DATA_PATH) / "keysigs.musx");
+    ASSERT_TRUE(score);
+    ASSERT_EQ(score->parts.size(), 1);
+
+    constexpr size_t nonTraditionalKeyMeasureIndex = 4;
+    const auto& measures = score->parts.front().measures;
+    ASSERT_GT(measures.size(), nonTraditionalKeyMeasureIndex);
+    ASSERT_EQ(measures[nonTraditionalKeyMeasureIndex].keys.size(), 1);
+    const auto& components = measures[nonTraditionalKeyMeasureIndex].keys.front().nonTraditional;
+    const std::vector expected{
+        mx::api::KeyComponent{ mx::api::Step::b, -1, 0.0, mx::api::Accidental::flat },
+        mx::api::KeyComponent{ mx::api::Step::e, -1, 0.0, mx::api::Accidental::flat },
+        mx::api::KeyComponent{ mx::api::Step::f, 1, 0.0, mx::api::Accidental::sharp }
+    };
+    EXPECT_EQ(components, expected);
+
+    auto& documentManager = mx::api::DocumentManager::getInstance();
+    const auto documentIdResult = documentManager.createFromScore(*score);
+    ASSERT_TRUE(documentIdResult.ok()) << documentIdResult.error().message;
+    const int documentId = documentIdResult.value();
+    std::ostringstream output;
+    const auto writeResult = documentManager.writeToStream(documentId, output);
+    documentManager.destroyDocument(documentId);
+    ASSERT_TRUE(writeResult.ok()) << writeResult.error().message;
+
+    pugi::xml_document document;
+    ASSERT_TRUE(document.load_string(output.str().c_str()));
+    const auto keySteps = document.select_nodes("(//measure)[5]/attributes/key/key-step");
+    const auto keyAlters = document.select_nodes("(//measure)[5]/attributes/key/key-alter");
+    const auto keyAccidentals = document.select_nodes("(//measure)[5]/attributes/key/key-accidental");
+    ASSERT_EQ(keySteps.size(), expected.size());
+    ASSERT_EQ(keyAlters.size(), expected.size());
+    ASSERT_EQ(keyAccidentals.size(), expected.size());
+    const std::array expectedSteps{ "B", "E", "F" };
+    const std::array expectedAlters{ "-1", "-1", "1" };
+    const std::array expectedAccidentals{ "flat", "flat", "sharp" };
+    for (size_t index = 0; index < expected.size(); ++index) {
+        EXPECT_STREQ(keySteps[index].node().child_value(), expectedSteps[index]);
+        EXPECT_STREQ(keyAlters[index].node().child_value(), expectedAlters[index]);
+        EXPECT_STREQ(keyAccidentals[index].node().child_value(), expectedAccidentals[index]);
     }
 }
 

--- a/tests/musicxml/test_parts.cpp
+++ b/tests/musicxml/test_parts.cpp
@@ -675,6 +675,26 @@ TEST(MusicXmlParts, IndependentKeySignaturesMatchFinale)
     compareKeySignatures(*actualScore, *expectedScore);
 }
 
+TEST(MusicXmlParts, InstrumentNameUsesSoundIdString)
+{
+    setupTestDataPaths();
+
+    const auto score = createScoreDataFromMusxPath(std::filesystem::path(MUSX_TEST_DATA_PATH) / "keysigs.musx");
+    ASSERT_TRUE(score);
+    ASSERT_EQ(score->parts.size(), 1);
+    const auto& instrument = score->parts.front().instrumentData;
+    EXPECT_EQ(instrument.soundID, mx::api::SoundID::unspecified);
+    EXPECT_EQ(instrument.name, musx::dom::uuid::BlankStaff);
+
+    const auto mappedScore = createScoreDataFromMusicXmlFixture("transposition.musx");
+    ASSERT_TRUE(mappedScore);
+    ASSERT_FALSE(mappedScore->parts.empty());
+    for (const auto& part : mappedScore->parts) {
+        ASSERT_NE(part.instrumentData.soundID, mx::api::SoundID::unspecified);
+        EXPECT_EQ(part.instrumentData.name, mx::api::SoundIDToString(part.instrumentData.soundID));
+    }
+}
+
 TEST(MusicXmlParts, StandardDiatonicModesUseMusicXmlModes)
 {
     const std::array expected{


### PR DESCRIPTION
## Summary

- export authored Finale page breaks as MusicXML `new-page` layout instructions
- export nontraditional 12-EDO key signatures as ordered key-step, key-alter, and key-accidental components
- populate required score-instrument names from SoundID strings, authored instrument names, or instrument UUIDs
- remove completed cue-note and page-break items from the MusicXML backlog

## Verification

- `cmake --build build`
- focused MusicXmlDefaults page/system break tests
- focused MusicXmlParts key-signature tests
- focused MusicXmlParts instrument-name test
- `git diff --check`